### PR TITLE
Added support for pyarrow >==9.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ datadoc = 'datadoc.app:main'
 [tool.poetry.dependencies]
 python = ">3.10,<4.0"
 requests = ">=2.27.1"
-pyarrow = ">=8.0.0"
+pyarrow = ">=8.0.0, >=9.0.0"
 jupyter-dash = ">=0.4.2"
 dash = ">=2.4.1"
 pydantic = ">=1.9.1"


### PR DESCRIPTION
As far as I can tell the version qualifier `pyarrow>=8.0.0` is interpreted as `pyarrow<9.0.0,>=8.0.0`. So, to be able to support **both minor and major versions** of pyarrow from 8.0.0 and onwards, one must specify each major version like in this PR. Please correct me if I'm wrong.
