### PR TITLE
Add Dapla lab CI

### DIFF
--- a/.github/workflows/dapla-lab-ci.yml
+++ b/.github/workflows/dapla-lab-ci.yml
@@ -1,0 +1,76 @@
+name: Datadoc Dapla Lab CI
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - 'datadoc/**'
+      - 'poetry.lock'
+      - 'Dockerfile'
+    tags:
+      - "*"
+  pull_request:
+    paths:
+      - 'datadoc/**'
+      - 'poetry.lock'
+      - 'Dockerfile'
+
+env:
+  REGISTRY: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia
+  IMAGE: datadoc
+  TAG: ${{ github.ref_name }}-${{ github.sha }}
+
+jobs:
+  docker:
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1.1.1"
+        with:
+          workload_identity_provider: "projects/848539402404/locations/global/workloadIdentityPools/gh-actions/providers/gh-actions"
+          service_account: "gh-actions-dapla-lab@artifact-registry-5n.iam.gserviceaccount.com"
+          token_format: "access_token"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
+      - name: Docker meta
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          # Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+            type=raw,value=${{ env.TAG }}, enable=true
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: datadoc
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dapla-lab-ci.yml
+++ b/.github/workflows/dapla-lab-ci.yml
@@ -15,6 +15,7 @@ on:
       - 'datadoc/**'
       - 'poetry.lock'
       - 'Dockerfile'
+  workflow_dispatch:
 
 env:
   REGISTRY: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia

--- a/.github/workflows/dapla-lab-ci.yml
+++ b/.github/workflows/dapla-lab-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'datadoc/**'
       - 'poetry.lock'
       - 'Dockerfile'
+      - '.github/workflows/dapla-lab-ci.yml'
     tags:
       - "*"
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'datadoc/**'
       - 'poetry.lock'
       - 'Dockerfile'
+      - '.github/workflows/dapla-lab-ci.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/dapla-lab-ci.yml
+++ b/.github/workflows/dapla-lab-ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: datadoc
+          context: .
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
           push: true

--- a/.github/workflows/dapla-lab-ci.yml
+++ b/.github/workflows/dapla-lab-ci.yml
@@ -17,7 +17,6 @@ on:
       - 'poetry.lock'
       - 'Dockerfile'
       - '.github/workflows/dapla-lab-ci.yml'
-  workflow_dispatch:
 
 env:
   REGISTRY: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia

--- a/datadoc/backend/storage_adapter.py
+++ b/datadoc/backend/storage_adapter.py
@@ -92,7 +92,7 @@ class LocalFile:
 
     def open(self: t.Self @ LocalFile, **kwargs: dict[str, t.Any]) -> IOBase:
         """Return a file-like-object."""
-        return pathlib.Path.open(str(self._path_object), **kwargs)
+        return pathlib.Path.open(self._path_object, **kwargs)
 
     def parent(self: t.Self @ LocalFile) -> str:
         """Return the parent of this file."""

--- a/datadoc/tests/test_datadoc_metadata.py
+++ b/datadoc/tests/test_datadoc_metadata.py
@@ -159,12 +159,12 @@ def test_existing_metadata_none_id(
 ):
     pre_open_id = ""
     post_write_id = ""
-    with Path.open(existing_metadata_file) as f:
+    with Path.open(Path(existing_metadata_file)) as f:
         pre_open_id = json.load(f)["dataset"]["id"]
     assert pre_open_id is None
     assert isinstance(metadata.meta.dataset.id, UUID)
     metadata.write_metadata_document()
-    with Path.open(existing_metadata_file) as f:
+    with Path.open(Path(existing_metadata_file)) as f:
         post_write_id = json.load(f)["dataset"]["id"]
     assert post_write_id == str(metadata.meta.dataset.id)
 
@@ -180,13 +180,13 @@ def test_existing_metadata_valid_id(
 ):
     pre_open_id = ""
     post_write_id = ""
-    with Path.open(existing_metadata_file) as f:
+    with Path.open(Path(existing_metadata_file)) as f:
         pre_open_id = json.load(f)["dataset"]["id"]
     assert pre_open_id is not None
     assert isinstance(metadata.meta.dataset.id, UUID)
     assert str(metadata.meta.dataset.id) == pre_open_id
     metadata.write_metadata_document()
-    with Path.open(existing_metadata_file) as f:
+    with Path.open(Path(existing_metadata_file)) as f:
         post_write_id = json.load(f)["dataset"]["id"]
     assert post_write_id == pre_open_id
 

--- a/datadoc/tests/test_model_backwards_compatibility.py
+++ b/datadoc/tests/test_model_backwards_compatibility.py
@@ -46,7 +46,7 @@ def test_backwards_compatibility(
     metadata: DataDocMetadata,
 ):
     # Parameterise with all known backwards compatible versions
-    with Path.open(existing_metadata_file) as f:
+    with Path.open(Path(existing_metadata_file)) as f:
         file_metadata = json.loads(f.read())
 
     in_file_values = [

--- a/datadoc/wsgi.py
+++ b/datadoc/wsgi.py
@@ -2,5 +2,5 @@
 
 from .app import get_app
 
-datadoc_app = get_app()
+datadoc_app, _ = get_app()
 server = datadoc_app.server


### PR DESCRIPTION
Add workflow that builds datadoc image to GAR 'dapla-lab-docker'. 

### Other changes
- There was a problem in the 'wsgi.py', this broke the image build. This was fix it by unpacking the tuple from get_app.
- Pass paths as Path objects to fix tests