### PR TITLE
Set fixture remove_document_file on autouse

### DIFF
--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -62,7 +62,7 @@ def test_get_dataset_state(
     assert actual_state == expected_result
 
 
-@pytest.mark.usefixtures("existing_metadata_file", "remove_document_file")
+@pytest.mark.usefixtures("existing_metadata_file")
 def test_existing_metadata_file(
     metadata: DataDocMetadata,
 ):
@@ -99,7 +99,6 @@ def test_get_dataset_version(
     assert DataDocMetadata.get_dataset_version(short_name) == expected
 
 
-@pytest.mark.usefixtures("remove_document_file")
 def test_write_metadata_document(
     dummy_timestamp: datetime,
     metadata: DataDocMetadata,
@@ -134,7 +133,7 @@ def test_write_metadata_document(
     assert datadoc_metadata["metadata_last_updated_by"] == PLACEHOLDER_USERNAME
 
 
-@pytest.mark.usefixtures("existing_metadata_file", "remove_document_file")
+@pytest.mark.usefixtures("existing_metadata_file")
 def test_write_metadata_document_existing_document(
     dummy_timestamp: datetime,
     metadata: DataDocMetadata,
@@ -156,7 +155,6 @@ def test_metadata_id(metadata: DataDocMetadata):
     "existing_metadata_path",
     [TEST_EXISTING_METADATA_DIRECTORY / "invalid_id_field"],
 )
-@pytest.mark.usefixtures("remove_document_file")
 def test_existing_metadata_none_id(
     existing_metadata_file: str,
     metadata: DataDocMetadata,
@@ -175,7 +173,6 @@ def test_existing_metadata_none_id(
     "existing_metadata_path",
     [TEST_EXISTING_METADATA_DIRECTORY / "valid_id_field"],
 )
-@pytest.mark.usefixtures("remove_document_file")
 def test_existing_metadata_valid_id(
     existing_metadata_file: str,
     metadata: DataDocMetadata,

--- a/tests/backend/test_model_backwards_compatibility.py
+++ b/tests/backend/test_model_backwards_compatibility.py
@@ -36,7 +36,6 @@ def test_existing_metadata_unknown_model_version():
     BACKWARDS_COMPATIBLE_VERSION_DIRECTORIES,
     ids=BACKWARDS_COMPATIBLE_VERSION_NAMES,
 )
-@pytest.mark.usefixtures("remove_document_file")
 def test_backwards_compatibility(
     existing_metadata_file: str,
     metadata: DataDocMetadata,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,12 +43,13 @@ def metadata(_mock_timestamp: None) -> DataDocMetadata:
     return DataDocMetadata(str(TEST_PARQUET_FILEPATH))
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def remove_document_file() -> Generator[None, None, None]:
     # Yield so we only run teardown
     yield None
     try:
-        TEST_RESOURCES_METADATA_DOCUMENT.unlink()
+        if TEST_RESOURCES_METADATA_DOCUMENT.exists():
+            TEST_RESOURCES_METADATA_DOCUMENT.unlink()
     except FileNotFoundError as e:
         print("File not deleted on teardown, exception caught:")  # noqa: T201
         traceback.print_exception(type(e), e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Shared fixtures and configuration."""
 
 import shutil
-import traceback
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
@@ -47,12 +46,8 @@ def metadata(_mock_timestamp: None) -> DataDocMetadata:
 def remove_document_file() -> Generator[None, None, None]:
     # Yield so we only run teardown
     yield None
-    try:
-        if TEST_RESOURCES_METADATA_DOCUMENT.exists():
-            TEST_RESOURCES_METADATA_DOCUMENT.unlink()
-    except FileNotFoundError as e:
-        print("File not deleted on teardown, exception caught:")  # noqa: T201
-        traceback.print_exception(type(e), e)
+    if TEST_RESOURCES_METADATA_DOCUMENT.exists():
+        TEST_RESOURCES_METADATA_DOCUMENT.unlink()
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Fixture offers reusable code for tests
- The method remove_document_file removes links to file created in tests
- It is good practice to clean up after tests 
- With autouse on fixture the method is run automatically on all tests