### PR TITLE
Add config option for statistical subject source url

### DIFF
--- a/src/datadoc/config.py
+++ b/src/datadoc/config.py
@@ -1,4 +1,5 @@
 """Centralised configuration management for Datadoc."""
+
 from __future__ import annotations
 
 import logging
@@ -82,3 +83,8 @@ def get_jupyterhub_http_referrer() -> str | None:
 def get_port() -> int:
     """Get the port to run the app on."""
     return int(_get_config_item("DATADOC_PORT") or 7002)
+
+
+def get_statistical_subject_source_url() -> str | None:
+    """Get the URL to the statistical subject source."""
+    return _get_config_item("DATADOC_STATISTICAL_SUBJECT_SOURCE_URL")


### PR DESCRIPTION
This will avoid hard-coding this value.

Description for how it may be used for local development: https://statisticsnorway.github.io/datadoc/contributing.html#config-for-local-development

Ref: DPMETA-13