### PR TITLE
Avoid AttributeErrors on access of global

### DIFF
--- a/src/datadoc/app.py
+++ b/src/datadoc/app.py
@@ -111,14 +111,9 @@ def collect_data_from_external_sources() -> None:
 
     Must be non-blocking to prevent delays in app startup.
     """
-    if source_url := config.get_statistical_subject_source_url():
-        state.statistic_subject_mapping = StatisticSubjectMapping(
-            source_url,
-        )
-    else:
-        logger.warning(
-            "No URL to fetch statistical subject structure supplied. Skipping fetching it. This may make it difficult to provide a value for the 'subject_field' metadata field.",
-        )
+    state.statistic_subject_mapping = StatisticSubjectMapping(
+        config.get_statistical_subject_source_url(),
+    )
 
 
 def main(dataset_path: str | None = None) -> None:

--- a/src/datadoc/backend/datadoc_metadata.py
+++ b/src/datadoc/backend/datadoc_metadata.py
@@ -173,12 +173,9 @@ class DataDocMetadata:
         self.ds_schema: DatasetParser = DatasetParser.for_file(dataset)
         dapla_dataset_path_info = DaplaDatasetPathInfo(dataset)
 
-        if dapla_dataset_path_info.statistic_short_name:
-            subject_field = state.statistic_subject_mapping.get_secondary_subject(
-                dapla_dataset_path_info.statistic_short_name,
-            )
-        else:
-            subject_field = None
+        subject_field = state.statistic_subject_mapping.get_secondary_subject(
+            dapla_dataset_path_info.statistic_short_name,
+        )
 
         self.meta.dataset = model.Dataset(
             short_name=self.short_name,

--- a/src/datadoc/backend/statistic_subject_mapping.py
+++ b/src/datadoc/backend/statistic_subject_mapping.py
@@ -132,6 +132,9 @@ class StatisticSubjectMapping:
 
     def wait_for_primary_subject(self) -> None:
         """Waits for the thread responsible for loading the xml to finish."""
+        if not self.future:
+            # Nothing to wait for in this case, just return immediately
+            return
         self.future.result()
 
     @property

--- a/src/datadoc/backend/statistic_subject_mapping.py
+++ b/src/datadoc/backend/statistic_subject_mapping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import logging
 from dataclasses import dataclass
 
 import bs4
@@ -9,6 +10,8 @@ from bs4 import BeautifulSoup
 from bs4 import ResultSet
 
 from datadoc.enums import SupportedLanguages
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -51,42 +54,30 @@ class PrimarySubject(Subject):
 class StatisticSubjectMapping:
     """Allow mapping between statistic short name and primary and secondary subject."""
 
-    def __init__(self, source_url: str) -> None:
+    def __init__(self, source_url: str | None) -> None:
         """Retrieves the statistical structure document from the given URL.
 
         Initializes the mapping dicts. Based on the values in the statistical structure document.
         """
         self.source_url = source_url
 
+        self.future: concurrent.futures.Future[ResultSet] | None = None
         self._statistic_subject_structure_xml: ResultSet | None = None
-        self.secondary_subject_primary_subject_mapping: dict[str, str] = {}
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        self.future = executor.submit(
-            self._fetch_statistical_structure,
-            self.source_url,
-        )
-
-        self._primary_subjects: list[PrimarySubject]
-
-    def get_primary_subject(self, statistic_short_name: str) -> str | None:
-        """Returns the primary subject for the given statistic short name by mapping it through the secondary subject.
-
-        Looks up the secondary subject for the statistic short name, then uses that
-        to look up the corresponding primary subject in the mapping dict.
-
-        Returns the primary subject string if found, else None.
-        """
-        self._parse_xml_if_loaded()
-        if secondary_subject := self.get_secondary_subject(statistic_short_name):
-            return self.secondary_subject_primary_subject_mapping.get(
-                secondary_subject,
-                None,
+        if self.source_url:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            self.future = executor.submit(
+                self._fetch_statistical_structure,
+                self.source_url,
+            )
+        else:
+            logger.warning(
+                "No URL to fetch statistical subject structure supplied. Skipping fetching it. This may make it difficult to provide a value for the 'subject_field' metadata field.",
             )
 
-        return None
+        self._primary_subjects: list[PrimarySubject] = []
 
-    def get_secondary_subject(self, statistic_short_name: str) -> str | None:
+    def get_secondary_subject(self, statistic_short_name: str | None) -> str | None:
         """Looks up the secondary subject for the given statistic short name in the mapping dict.
 
         Returns the secondary subject string if found, else None.
@@ -154,7 +145,7 @@ class StatisticSubjectMapping:
 
         Returns true if it is loaded and parsed.
         """
-        if self.future.done():
+        if self.future and self.future.done():
             self._statistic_subject_structure_xml = self.future.result()
 
             self._primary_subjects = self._parse_statistic_subject_structure_xml(

--- a/src/datadoc/frontend/fields/display_dataset.py
+++ b/src/datadoc/frontend/fields/display_dataset.py
@@ -43,18 +43,14 @@ def get_statistical_subject_options(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
     """Collect the statistical subject options for the given language."""
-    try:
-        return [
-            {
-                "label": f"{primary.get_title(language)} - {secondary.get_title(language)}",
-                "value": secondary.subject_code,
-            }
-            for primary in state.statistic_subject_mapping.primary_subjects
-            for secondary in primary.secondary_subjects
-        ]
-    except AttributeError:
-        logger.warning("Could not populate Dropdown options for Statistical Subjects.")
-        return []
+    return [
+        {
+            "label": f"{primary.get_title(language)} - {secondary.get_title(language)}",
+            "value": secondary.subject_code,
+        }
+        for primary in state.statistic_subject_mapping.primary_subjects
+        for secondary in primary.secondary_subjects
+    ]
 
 
 class DatasetIdentifiers(str, Enum):

--- a/tests/backend/test_statistic_subject_mapping.py
+++ b/tests/backend/test_statistic_subject_mapping.py
@@ -61,6 +61,7 @@ def test_read_in_statistical_structure(
         ("ab_kortnvan_01", "ab01"),
         ("aa_kortnvan_01", "aa01"),
         ("unknown_name", None),
+        (None, None),
     ],
 )
 @pytest.mark.usefixtures("_mock_fetch_statistical_structure")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,11 @@ def _mock_timestamp(mocker: MockerFixture, dummy_timestamp: datetime) -> None:
 
 
 @pytest.fixture()
-def metadata(_mock_timestamp: None) -> DataDocMetadata:
+def metadata(
+    _mock_timestamp: None,
+    subject_mapping: StatisticSubjectMapping,
+) -> DataDocMetadata:
+    state.statistic_subject_mapping = subject_mapping
     return DataDocMetadata(str(TEST_PARQUET_FILEPATH))
 
 


### PR DESCRIPTION
This way there is always an object present, which returns empty data when a URL isn't supplied.

Ref: DPMETA-13