### PR TITLE
Inject dependency into DatadocMetadata

### DIFF
--- a/src/datadoc/backend/datadoc_metadata.py
+++ b/src/datadoc/backend/datadoc_metadata.py
@@ -15,7 +15,6 @@ from dapla import AuthClient
 from datadoc_model import model
 
 from datadoc import config
-from datadoc import state
 from datadoc.backend.dapla_dataset_path_info import DaplaDatasetPathInfo
 from datadoc.backend.dataset_parser import DatasetParser
 from datadoc.backend.model_backwards_compatibility import upgrade_metadata
@@ -33,6 +32,8 @@ from datadoc.utils import get_timestamp_now
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from datadoc.backend.statistic_subject_mapping import StatisticSubjectMapping
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,10 +42,12 @@ class DataDocMetadata:
 
     def __init__(
         self,
+        statistic_subject_mapping: StatisticSubjectMapping,
         dataset_path: str | None = None,
         metadata_document_path: str | None = None,
     ) -> None:
         """Read in a dataset if supplied, otherwise naively instantiate the class."""
+        self._statistic_subject_mapping = statistic_subject_mapping
         self.dataset_path = dataset_path
 
         self.metadata_document: pathlib.Path | CloudPath | None = None
@@ -173,7 +176,7 @@ class DataDocMetadata:
         self.ds_schema: DatasetParser = DatasetParser.for_file(dataset)
         dapla_dataset_path_info = DaplaDatasetPathInfo(dataset)
 
-        subject_field = state.statistic_subject_mapping.get_secondary_subject(
+        subject_field = self._statistic_subject_mapping.get_secondary_subject(
             dapla_dataset_path_info.statistic_short_name,
         )
 

--- a/src/datadoc/frontend/callbacks/dataset.py
+++ b/src/datadoc/frontend/callbacks/dataset.py
@@ -29,11 +29,14 @@ def open_file(file_path: str | None = None) -> DataDocMetadata:
     """Load the given dataset into a DataDocMetadata instance."""
     if file_path and file_path.endswith(METADATA_DOCUMENT_FILE_SUFFIX):
         logger.info("Opening existing metadata document %s", file_path)
-        return DataDocMetadata(metadata_document_path=file_path)
+        return DataDocMetadata(
+            state.statistic_subject_mapping,
+            metadata_document_path=file_path,
+        )
 
     dataset = file_path or get_dataset_path()
     logger.info("Opening dataset %s", dataset)
-    return DataDocMetadata(dataset_path=dataset)
+    return DataDocMetadata(state.statistic_subject_mapping, dataset_path=dataset)
 
 
 def open_dataset_handling(

--- a/src/datadoc/frontend/callbacks/utils.py
+++ b/src/datadoc/frontend/callbacks/utils.py
@@ -31,7 +31,9 @@ def update_global_language_state(language: SupportedLanguages) -> None:
     state.current_metadata_language = language
 
 
-def get_language_strings_enum(enum: Enum) -> enums.LanguageStringsEnum:
+def get_language_strings_enum(
+    enum: type[enums.LanguageStringsEnum],
+) -> enums.LanguageStringsEnum:
     """Get the correct language strings enum for the given enum.
 
     We need multiple languages to display in the front end, but the model only defines a single language in the enums.

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -15,7 +15,6 @@ from datadoc_model.model import DatadocJsonSchema
 from datadoc_model.model import Dataset
 from datadoc_model.model import Variable
 
-from datadoc import state
 from datadoc.backend.datadoc_metadata import PLACEHOLDER_USERNAME
 from datadoc.backend.datadoc_metadata import DataDocMetadata
 from datadoc.enums import DatasetState
@@ -188,11 +187,12 @@ def test_save_file_path_dataset_and_no_metadata(
     ],
 )
 def test_period_metadata_fields_saved(
+    subject_mapping: StatisticSubjectMapping,
     generate_periodic_file,
     expected_from,
     expected_until,
 ):
-    metadata = DataDocMetadata(str(generate_periodic_file))
+    metadata = DataDocMetadata(subject_mapping, str(generate_periodic_file))
     assert metadata.meta.dataset.contains_data_from == expected_from
     assert metadata.meta.dataset.contains_data_until == expected_until
 
@@ -250,11 +250,13 @@ def test_open_file(
     ],
 )
 def test_dataset_status_default_value(
+    subject_mapping: StatisticSubjectMapping,
     dataset_path: str,
     metadata_document_path: str | None,
     expected_type: DatasetStatus | None,
 ):
     datadoc_metadata = DataDocMetadata(
+        subject_mapping,
         dataset_path,
         metadata_document_path,
     )
@@ -271,14 +273,13 @@ def test_dataset_status_default_value(
         (["unknown_short_name", "klargjorte_data"], None),
     ],
 )
-def test_extract_subject_field_value_from_statistic_(
+def test_extract_subject_field_value_from_statistic_structure_xml(
     subject_mapping: StatisticSubjectMapping,
     copy_dataset_to_path: Path,
     expected_subject_code: str,
 ):
-    state.statistic_subject_mapping = subject_mapping
-    state.statistic_subject_mapping.wait_for_primary_subject()
-    metadata = DataDocMetadata(str(copy_dataset_to_path))
+    subject_mapping.wait_for_primary_subject()
+    metadata = DataDocMetadata(subject_mapping, str(copy_dataset_to_path))
     # TODO @mmwinther: Remove multiple_language_support once the model is updated.
     # https://github.com/statisticsnorway/ssb-datadoc-model/issues/41
     assert metadata.meta.dataset.subject_field.en == expected_subject_code

--- a/tests/callbacks/test_variables_callbacks.py
+++ b/tests/callbacks/test_variables_callbacks.py
@@ -1,14 +1,15 @@
 """Tests for the callbacks package."""
+
 from __future__ import annotations
 
 import random
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import pytest
 from datadoc_model import model
 
 from datadoc import state
-from datadoc.backend.datadoc_metadata import DataDocMetadata
 from datadoc.enums import DataType
 from datadoc.enums import SupportedLanguages
 from datadoc.frontend.callbacks.utils import MetadataInputTypes
@@ -19,7 +20,9 @@ from datadoc.frontend.callbacks.variables import (
 )
 from datadoc.frontend.callbacks.variables import update_variable_table_language
 from datadoc.frontend.fields.display_variables import VariableIdentifiers
-from tests.utils import TEST_PARQUET_FILEPATH
+
+if TYPE_CHECKING:
+    from datadoc.backend.datadoc_metadata import DataDocMetadata
 
 DATA_ORIGINAL = [
     {
@@ -64,9 +67,10 @@ def test_accept_variable_metadata_input_no_change_in_data(
 
 
 def test_accept_variable_metadata_input_new_data(
+    metadata: DataDocMetadata,
     active_cell: dict[str, MetadataInputTypes],
 ):
-    state.metadata = DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    state.metadata = metadata
     output = accept_variable_metadata_input(DATA_VALID, active_cell, DATA_ORIGINAL)
 
     assert state.metadata.variables_lookup["pers_id"].variable_role == "IDENTIFIER"
@@ -76,9 +80,10 @@ def test_accept_variable_metadata_input_new_data(
 
 
 def test_accept_variable_metadata_clear_string(
+    metadata: DataDocMetadata,
     active_cell: dict[str, MetadataInputTypes],
 ):
-    state.metadata = DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    state.metadata = metadata
     output = accept_variable_metadata_input(DATA_CLEAR_URI, active_cell, DATA_ORIGINAL)
 
     assert state.metadata.variables_lookup["pers_id"].definition_uri is None
@@ -88,9 +93,10 @@ def test_accept_variable_metadata_clear_string(
 
 
 def test_accept_variable_metadata_input_incorrect_data_type(
+    metadata: DataDocMetadata,
     active_cell: dict[str, MetadataInputTypes],
 ):
-    state.metadata = DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    state.metadata = metadata
     previous_metadata = deepcopy(state.metadata.meta.variables)
     output = accept_variable_metadata_input(DATA_INVALID, active_cell, DATA_ORIGINAL)
 
@@ -122,10 +128,11 @@ def test_find_existing_language_string_pre_existing_strings(
 
 
 def test_update_variable_table_language(
+    metadata: DataDocMetadata,
     bokmål_name: str,
     language_object: model.LanguageStringType,
 ):
-    state.metadata = DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    state.metadata = metadata
     test_variable = random.choice(  # noqa: S311 not for cryptographic purposes
         [v.short_name for v in state.metadata.meta.variables],
     )
@@ -146,10 +153,11 @@ def test_update_variable_table_language(
 
 
 def test_nonetype_value_for_language_string(
+    metadata: DataDocMetadata,
     active_cell: dict[str, MetadataInputTypes],
     language_object: model.LanguageStringType,
 ):
-    state.metadata = DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    state.metadata = metadata
     state.metadata.variables_lookup["pers_id"].name = language_object
     state.current_metadata_language = SupportedLanguages.NORSK_NYNORSK
     accept_variable_metadata_input(DATA_NONETYPE, active_cell, DATA_ORIGINAL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from datadoc_model import model
 from datadoc import state
 from datadoc.backend.datadoc_metadata import DataDocMetadata
 from datadoc.backend.statistic_subject_mapping import StatisticSubjectMapping
-from datadoc.enums import SupportedLanguages
 from tests.backend.test_statistic_subject_mapping import (
     STATISTICAL_SUBJECT_STRUCTURE_DIR,
 )
@@ -55,8 +54,7 @@ def metadata(
     _mock_timestamp: None,
     subject_mapping: StatisticSubjectMapping,
 ) -> DataDocMetadata:
-    state.statistic_subject_mapping = subject_mapping
-    return DataDocMetadata(str(TEST_PARQUET_FILEPATH))
+    return DataDocMetadata(subject_mapping, str(TEST_PARQUET_FILEPATH))
 
 
 @pytest.fixture(autouse=True)
@@ -87,11 +85,15 @@ def existing_metadata_with_valid_id_file(existing_metadata_file: Path) -> Path:
     return existing_metadata_file
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def _clear_state() -> None:
     """Global fixture, referred to in pytest.ini."""
-    state.metadata = None  # type: ignore [assignment]
-    state.current_metadata_language = SupportedLanguages.NORSK_BOKMÅL
+    try:
+        del state.metadata
+        del state.current_metadata_language
+        del state.statistic_subject_mapping
+    except AttributeError:
+        pass
 
 
 @pytest.fixture()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-usefixtures = _clear_state


### PR DESCRIPTION
Also make the tests more robust by ensuring we clean up the state on tear-down.