### PR TITLE
Extract email address and save value in relevant fields

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -162,7 +162,7 @@ def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
     session.install(
-        "coverage[toml]", "pytest", "pygments", "pytest-mock", "requests-mock"
+        "coverage[toml]", "pytest", "pygments", "pytest-mock", "requests-mock", "faker"
     )
     try:
         session.run(
@@ -197,7 +197,9 @@ def coverage(session: Session) -> None:
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
-    session.install("pytest", "typeguard", "pygments", "pytest_mock", "requests_mock")
+    session.install(
+        "pytest", "typeguard", "pygments", "pytest_mock", "requests_mock", "faker"
+    )
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -151,6 +151,7 @@ def mypy(session: Session) -> None:
         "types-Pygments",
         "types-colorama",
         "types-beautifulsoup4",
+        "faker",
     )
     session.run("mypy", *args)
     if not session.posargs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -907,6 +907,20 @@ files = [
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
 
 [[package]]
+name = "faker"
+version = "23.2.1"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-23.2.1-py3-none-any.whl", hash = "sha256:0520a6b97e07c658b2798d7140971c1d5bc4bcd5013e7937fe075fd054aa320c"},
+    {file = "Faker-23.2.1.tar.gz", hash = "sha256:f07b64d27f67b62c7f0536a72f47813015b3b51cd4664918454011094321e464"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "fastjsonschema"
 version = "2.19.1"
 description = "Fastest Python implementation of JSON schema"
@@ -4382,4 +4396,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "c8e4e9bb9f0be24c8ea766b0d79d1e745d6c9844c5410e455505cf675c0f6615"
+content-hash = "b9cb2cab915ef305dc20f0df7558459bfad8d04a77db26acc35d3c9f92c1259b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ python-dotenv = ">=1.0.1"
 requests = ">=2.31.0"
 beautifulsoup4 = ">=4.12.3"
 cloudpathlib = { extras = ["gs"], version = ">=0.17.0" }
+pyjwt = "^2.8.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=0.950"
@@ -67,6 +68,7 @@ types-colorama = "*"
 types-setuptools = "*"
 types-beautifulsoup4 = "^4.12.0.20240106"
 requests-mock = "^1.11.0"
+faker = "^23.2.1"
 
 
 [tool.pytest.ini_options]

--- a/src/datadoc/backend/user_info.py
+++ b/src/datadoc/backend/user_info.py
@@ -4,6 +4,8 @@ import logging
 from typing import Protocol
 
 from datadoc import config
+from datadoc.enums import DaplaRegion
+from datadoc.enums import DaplaService
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,15 @@ class TestUserInfo:
         return PLACEHOLDER_EMAIL_ADDRESS
 
 
+class DaplaLabUserInfo:
+    """Information about the current user when running on Dapla Lab."""
+
+    @property
+    def short_email(self) -> str | None:
+        """Get the short email address."""
+        raise NotImplementedError
+
+
 class JupyterHubUserInfo:
     """Information about the current user when running on JupyterHub."""
 
@@ -52,10 +63,12 @@ class JupyterHubUserInfo:
 
 def get_user_info_for_current_platform() -> UserInfo:
     """Return the correct implementation of UserInfo for the current platform."""
-    if JupyterHubUserInfo().short_email:
+    if config.get_dapla_region() == DaplaRegion.DAPLA_LAB:
+        return DaplaLabUserInfo()
+    elif config.get_dapla_service() == DaplaService.JUPYTERLAB:  # noqa: RET505
         return JupyterHubUserInfo()
-
-    logger.warning(
-        "Was not possible to retrieve user information! Some fields may not be set.",
-    )
-    return UnknownUserInfo()
+    else:
+        logger.warning(
+            "Was not possible to retrieve user information! Some fields may not be set.",
+        )
+        return UnknownUserInfo()

--- a/src/datadoc/config.py
+++ b/src/datadoc/config.py
@@ -10,6 +10,9 @@ from pprint import pformat
 from dotenv import dotenv_values
 from dotenv import load_dotenv
 
+from datadoc.enums import DaplaRegion
+from datadoc.enums import DaplaService
+
 logging.basicConfig(level=logging.DEBUG, force=True)
 
 logger = logging.getLogger(__name__)
@@ -17,6 +20,8 @@ logger = logging.getLogger(__name__)
 DOT_ENV_FILE_PATH = Path(__file__).parent.joinpath(".env")
 
 JUPYTERHUB_USER = "JUPYTERHUB_USER"
+DAPLA_REGION = "DAPLA_REGION"
+DAPLA_SERVICE = "DAPLA_SERVICE"
 
 load_dotenv(DOT_ENV_FILE_PATH)
 
@@ -90,3 +95,19 @@ def get_port() -> int:
 def get_statistical_subject_source_url() -> str | None:
     """Get the URL to the statistical subject source."""
     return _get_config_item("DATADOC_STATISTICAL_SUBJECT_SOURCE_URL")
+
+
+def get_dapla_region() -> DaplaRegion | None:
+    """Get the Dapla region we're running on."""
+    if region := _get_config_item(DAPLA_REGION):
+        return DaplaRegion(region)
+
+    return None
+
+
+def get_dapla_service() -> DaplaService | None:
+    """Get the Dapla service we're running on."""
+    if service := _get_config_item(DAPLA_SERVICE):
+        return DaplaService(service)
+
+    return None

--- a/src/datadoc/config.py
+++ b/src/datadoc/config.py
@@ -23,16 +23,23 @@ JUPYTERHUB_USER = "JUPYTERHUB_USER"
 DAPLA_REGION = "DAPLA_REGION"
 DAPLA_SERVICE = "DAPLA_SERVICE"
 
-load_dotenv(DOT_ENV_FILE_PATH)
+env_loaded = False
 
-logger.info(
-    "Loaded .env file with config keys: \n%s",
-    pformat(list(dotenv_values(DOT_ENV_FILE_PATH).keys())),
-)
+
+def _load_dotenv_file() -> None:
+    global env_loaded  # noqa: PLW0603
+    if not env_loaded and DOT_ENV_FILE_PATH.exists():
+        load_dotenv(DOT_ENV_FILE_PATH)
+        env_loaded = True
+        logger.info(
+            "Loaded .env file with config keys: \n%s",
+            pformat(list(dotenv_values(DOT_ENV_FILE_PATH).keys())),
+        )
 
 
 def _get_config_item(item: str) -> str | None:
     """Get a config item. Makes sure all access is logged."""
+    _load_dotenv_file()
     value = os.getenv(item)
     logger.debug("Config accessed. %s", item)
     return value
@@ -111,3 +118,8 @@ def get_dapla_service() -> DaplaService | None:
         return DaplaService(service)
 
     return None
+
+
+def get_oidc_token() -> str | None:
+    """Get the JWT token from the environment."""
+    return _get_config_item("OIDC_TOKEN")

--- a/src/datadoc/enums.py
+++ b/src/datadoc/enums.py
@@ -1,10 +1,30 @@
 """Enumerations used in Datadoc."""
+
 from __future__ import annotations
 
 from enum import Enum
 
 from datadoc_model import model
 from datadoc_model.model import LanguageStringType
+
+
+class DaplaRegion(str, Enum):
+    """Dapla platforms/regions."""
+
+    DAPLA_LAB = "DAPLA_LAB"
+    BIP = "BIP"
+    ON_PREM = "ON_PREM"
+    CLOUD_RUN = "CLOUD_RUN"
+
+
+class DaplaService(str, Enum):
+    """Dapla services."""
+
+    DATADOC = "DATADOC"
+    JUPYTERLAB = "JUPYTERLAB"
+    VS_CODE = "VS_CODE"
+    R_STUDIO = "R_STUDIO"
+    KILDOMATEN = "KILDOMATEN"
 
 
 class SupportedLanguages(str, Enum):

--- a/tests/backend/test_user_info.py
+++ b/tests/backend/test_user_info.py
@@ -1,4 +1,8 @@
+import string
+
+import jwt
 import pytest
+from faker import Faker
 
 from datadoc.backend import user_info
 from datadoc.backend.user_info import PLACEHOLDER_EMAIL_ADDRESS
@@ -11,6 +15,55 @@ from datadoc.config import DAPLA_SERVICE
 from datadoc.config import JUPYTERHUB_USER
 from datadoc.enums import DaplaRegion
 from datadoc.enums import DaplaService
+
+
+@pytest.fixture()
+def raw_jwt_payload(faker: Faker) -> dict[str, object]:
+    user_name = "".join(faker.random_sample(elements=string.ascii_lowercase, length=3))
+    email = f"{user_name}@ssb.no"
+    first_name = faker.first_name()
+    last_name = faker.last_name()
+    return {
+        "exp": faker.unix_time(),
+        "iat": faker.unix_time(),
+        "auth_time": faker.unix_time(),
+        "jti": faker.uuid4(),
+        "iss": faker.url(),
+        "aud": [
+            faker.word(),
+            faker.uuid4(),
+            "broker",
+            "account",
+        ],
+        "sub": faker.uuid4(),
+        "typ": "Bearer",
+        "azp": "onyxia",
+        "session_state": faker.uuid4(),
+        "allowed-origins": ["*"],
+        "realm_access": {
+            "roles": [faker.word(), faker.word()],
+        },
+        "resource_access": {
+            "broker": {"roles": [faker.word()]},
+            "account": {
+                "roles": [faker.word()],
+            },
+        },
+        "scope": "openid email profile",
+        "sid": faker.uuid4(),
+        "email_verified": True,
+        "name": f"{first_name} {last_name}",
+        "short_username": f"ssb-{user_name}",
+        "preferred_username": email,
+        "given_name": first_name,
+        "family_name": last_name,
+        "email": email,
+    }
+
+
+@pytest.fixture()
+def fake_jwt(raw_jwt_payload):
+    return jwt.encode(raw_jwt_payload, "test secret", algorithm="HS256")
 
 
 @pytest.mark.parametrize(
@@ -37,5 +90,6 @@ def test_jupyterhub_user_info_short_email(monkeypatch):
     assert JupyterHubUserInfo().short_email == PLACEHOLDER_EMAIL_ADDRESS
 
 
-def test_dapla_lab_user_info_short_email():
-    assert DaplaLabUserInfo().short_email == "expected_value"
+def test_dapla_lab_user_info_short_email(fake_jwt: str, raw_jwt_payload, monkeypatch):
+    monkeypatch.setenv("OIDC_TOKEN", fake_jwt)
+    assert DaplaLabUserInfo().short_email == raw_jwt_payload["email"]

--- a/tests/backend/test_user_info.py
+++ b/tests/backend/test_user_info.py
@@ -2,16 +2,22 @@ import pytest
 
 from datadoc.backend import user_info
 from datadoc.backend.user_info import PLACEHOLDER_EMAIL_ADDRESS
+from datadoc.backend.user_info import DaplaLabUserInfo
 from datadoc.backend.user_info import JupyterHubUserInfo
 from datadoc.backend.user_info import UnknownUserInfo
 from datadoc.backend.user_info import UserInfo
+from datadoc.config import DAPLA_REGION
+from datadoc.config import DAPLA_SERVICE
 from datadoc.config import JUPYTERHUB_USER
+from datadoc.enums import DaplaRegion
+from datadoc.enums import DaplaService
 
 
 @pytest.mark.parametrize(
     ("environment_variable_name", "environment_variable_value", "expected_class"),
     [
-        (JUPYTERHUB_USER, PLACEHOLDER_EMAIL_ADDRESS, JupyterHubUserInfo),
+        (DAPLA_SERVICE, DaplaService.JUPYTERLAB, JupyterHubUserInfo),
+        (DAPLA_REGION, DaplaRegion.DAPLA_LAB, DaplaLabUserInfo),
         (None, None, UnknownUserInfo),
     ],
 )
@@ -29,3 +35,7 @@ def test_get_user_info_for_current_platform(
 def test_jupyterhub_user_info_short_email(monkeypatch):
     monkeypatch.setenv(JUPYTERHUB_USER, PLACEHOLDER_EMAIL_ADDRESS)
     assert JupyterHubUserInfo().short_email == PLACEHOLDER_EMAIL_ADDRESS
+
+
+def test_dapla_lab_user_info_short_email():
+    assert DaplaLabUserInfo().short_email == "expected_value"

--- a/tests/backend/test_user_info.py
+++ b/tests/backend/test_user_info.py
@@ -69,8 +69,8 @@ def fake_jwt(raw_jwt_payload):
 @pytest.mark.parametrize(
     ("environment_variable_name", "environment_variable_value", "expected_class"),
     [
-        (DAPLA_SERVICE, DaplaService.JUPYTERLAB, JupyterHubUserInfo),
-        (DAPLA_REGION, DaplaRegion.DAPLA_LAB, DaplaLabUserInfo),
+        (DAPLA_SERVICE, DaplaService.JUPYTERLAB.value, JupyterHubUserInfo),
+        (DAPLA_REGION, DaplaRegion.DAPLA_LAB.value, DaplaLabUserInfo),
         (None, None, UnknownUserInfo),
     ],
 )

--- a/tests/backend/test_user_info.py
+++ b/tests/backend/test_user_info.py
@@ -75,7 +75,7 @@ def fake_jwt(raw_jwt_payload):
     ],
 )
 def test_get_user_info_for_current_platform(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     environment_variable_name: str,
     environment_variable_value: str,
     expected_class: type[UserInfo],
@@ -85,11 +85,28 @@ def test_get_user_info_for_current_platform(
     assert isinstance(user_info.get_user_info_for_current_platform(), expected_class)
 
 
-def test_jupyterhub_user_info_short_email(monkeypatch):
+def test_jupyterhub_user_info_short_email(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(JUPYTERHUB_USER, PLACEHOLDER_EMAIL_ADDRESS)
     assert JupyterHubUserInfo().short_email == PLACEHOLDER_EMAIL_ADDRESS
 
 
-def test_dapla_lab_user_info_short_email(fake_jwt: str, raw_jwt_payload, monkeypatch):
+def test_dapla_lab_user_info_short_email(
+    fake_jwt: str,
+    raw_jwt_payload: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.setenv("OIDC_TOKEN", fake_jwt)
     assert DaplaLabUserInfo().short_email == raw_jwt_payload["email"]
+
+
+def test_dapla_lab_user_info_short_email_no_jwt_available():
+    assert DaplaLabUserInfo().short_email is None
+
+
+@pytest.mark.parametrize(("raw_jwt_payload"), [{"no_email": "no_email_in_jwt"}])
+def test_dapla_lab_user_info_short_email_no_email_in_jwt(
+    fake_jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("OIDC_TOKEN", fake_jwt)
+    assert DaplaLabUserInfo().short_email is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import functools
+import os
 import pathlib
 import shutil
 from datetime import datetime
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
     from unittest import mock
 
     from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def _clear_environment(mocker: MockerFixture) -> None:
+    """Ensure that the environment is cleared."""
+    mocker.patch.dict(os.environ, clear=True)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,11 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+@pytest.fixture(scope="session", autouse=True)
+def faker_session_locale():
+    return ["no_NO"]
+
+
 @pytest.fixture()
 def dummy_timestamp() -> datetime:
     return datetime(2022, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
- Update logic for getting `UserInfo` to use `DAPLA_REGION` and `DAPLA_SERVICE` environment variables
- Implementation to extract the user's `short_email` from the JWT token on Dapla Lab
- Prevent the latent environment from affecting unit tests
