### PR TITLE
Save and validate variable values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ exclude = ["docs/conf.py", "noxfile.py", "gunicorn.conf.py"]
 [[tool.mypy.overrides]]
 # Allow missing type hints in third-party libraries without type information.
 module = [
-    "dash",
+    "dash.*",
     "dash_bootstrap_components",
     "flask_healthz",
     "dapla",

--- a/src/datadoc/assets/variables_style.css
+++ b/src/datadoc/assets/variables_style.css
@@ -58,6 +58,14 @@
     margin: 1rem;
 }
 
+.alert-section{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: 1rem;
+    padding-top: 1rem;
+}
+
 .ssb-title.input-section-title{
     border-bottom: 2px solid #62919A;
     margin-bottom: 1rem;

--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -101,7 +101,7 @@ def handle_multi_language_metadata(
     return new_value
 
 
-def accept_variable_metadata_input(
+def accept_variable_datatable_metadata_input(
     data: list[dict],
     active_cell: dict,
     data_previous: list[dict],
@@ -209,3 +209,42 @@ def update_variable_table_language(
         False,  # Don't show validation error
         "",  # No validation explanation needed
     )
+
+
+def accept_variable_metadata_input(
+    value: MetadataInputTypes,
+    variable_short_name: str,
+    metadata_field: str,
+) -> None:
+    """Validate and save the value when variable metadata is updated."""
+    try:
+        if metadata_field in MULTIPLE_LANGUAGE_VARIABLES_METADATA:
+            new_value = handle_multi_language_metadata(
+                metadata_field,
+                value,
+                variable_short_name,
+            )
+        elif new_value == "":
+            # Allow clearing non-multiple-language text fields
+            new_value = None
+
+        # Write the value to the variables structure
+        setattr(
+            state.metadata.variables_lookup[variable_short_name],
+            metadata_field,
+            new_value,
+        )
+    except ValidationError:
+        logger.exception(
+            "Could not validate %s, %s, %s:",
+            metadata_field,
+            variable_short_name,
+            value,
+        )
+    else:
+        logger.debug(
+            "Successfully updated %s, %s with %s",
+            metadata_field,
+            variable_short_name,
+            value,
+        )

--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -215,8 +215,11 @@ def accept_variable_metadata_input(
     value: MetadataInputTypes,
     variable_short_name: str,
     metadata_field: str,
-) -> None:
-    """Validate and save the value when variable metadata is updated."""
+) -> str | None:
+    """Validate and save the value when variable metadata is updated.
+
+    Returns an error message if an exception was raised, otherwise returns None.
+    """
     try:
         if metadata_field in MULTIPLE_LANGUAGE_VARIABLES_METADATA:
             new_value = handle_multi_language_metadata(
@@ -224,9 +227,11 @@ def accept_variable_metadata_input(
                 value,
                 variable_short_name,
             )
-        elif new_value == "":
+        elif value == "":
             # Allow clearing non-multiple-language text fields
             new_value = None
+        else:
+            new_value = value
 
         # Write the value to the variables structure
         setattr(
@@ -234,13 +239,14 @@ def accept_variable_metadata_input(
             metadata_field,
             new_value,
         )
-    except ValidationError:
+    except ValidationError as e:
         logger.exception(
             "Could not validate %s, %s, %s:",
             metadata_field,
             variable_short_name,
             value,
         )
+        return str(e)
     else:
         logger.debug(
             "Successfully updated %s, %s with %s",
@@ -248,3 +254,4 @@ def accept_variable_metadata_input(
             variable_short_name,
             value,
         )
+        return None

--- a/src/datadoc/frontend/components/builders.py
+++ b/src/datadoc/frontend/components/builders.py
@@ -1,5 +1,7 @@
 """Factory functions for different components are defined here."""
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -24,7 +26,7 @@ class AlertType:
     color: str
 
     @staticmethod
-    def get_type(alert_type: AlertTypes) -> "AlertType":
+    def get_type(alert_type: AlertTypes) -> AlertType:
         """Get a concrete alert type based on the given enum values."""
         return ALERT_TYPES[alert_type]
 
@@ -54,17 +56,20 @@ def build_ssb_styled_tab(label: str, content: dbc.Container) -> dbc.Tab:
     )
 
 
-def build_ssb_alert(
+def build_ssb_alert(  # noqa: PLR0913 not immediately obvious how to improve this
     alert_type: AlertTypes,
     alert_identifier: str,
     title: str,
     content_identifier: str,
+    message: str | None = None,
+    *,
+    start_open: bool = False,
 ) -> dbc.Alert:
     """Make a Dash Alert according to SSBs Design System."""
     alert = AlertType.get_type(alert_type)
     return dbc.Alert(
         id=alert_identifier,
-        is_open=False,
+        is_open=start_open,
         dismissable=True,
         fade=True,
         color=alert.color,
@@ -75,8 +80,10 @@ def build_ssb_alert(
             ),
             html.P(
                 id=content_identifier,
+                children=message,
             ),
         ],
+        style={"width": "70%"},
     )
 
 

--- a/src/datadoc/frontend/components/resources_test_new_variables.py
+++ b/src/datadoc/frontend/components/resources_test_new_variables.py
@@ -78,6 +78,13 @@ def build_ssb_accordion(
         header=header,
         id=key,
         children=[
+            html.Section(
+                id={
+                    "type": "variable-input-alerts",
+                    "variable_short_name": variable_short_name,
+                },
+                className="alert-section",
+            ),
             build_edit_section(
                 OBLIGATORY_VARIABLES_METADATA,
                 "Obligatorisk",

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -14,7 +14,9 @@ from datadoc.enums import DataType
 from datadoc.enums import SupportedLanguages
 from datadoc.frontend.callbacks.utils import MetadataInputTypes
 from datadoc.frontend.callbacks.utils import find_existing_language_string
-from datadoc.frontend.callbacks.variables import accept_variable_metadata_input
+from datadoc.frontend.callbacks.variables import (
+    accept_variable_datatable_metadata_input,
+)
 from datadoc.frontend.callbacks.variables import (
     update_variable_table_dropdown_options_for_language,
 )
@@ -60,7 +62,11 @@ def test_accept_variable_metadata_input_no_change_in_data(
     active_cell: dict[str, MetadataInputTypes],
 ):
     state.metadata = metadata
-    output = accept_variable_metadata_input(DATA_ORIGINAL, active_cell, DATA_ORIGINAL)
+    output = accept_variable_datatable_metadata_input(
+        DATA_ORIGINAL,
+        active_cell,
+        DATA_ORIGINAL,
+    )
     assert output[0] == DATA_ORIGINAL
     assert output[1] is False
     assert output[2] == ""
@@ -71,7 +77,11 @@ def test_accept_variable_metadata_input_new_data(
     active_cell: dict[str, MetadataInputTypes],
 ):
     state.metadata = metadata
-    output = accept_variable_metadata_input(DATA_VALID, active_cell, DATA_ORIGINAL)
+    output = accept_variable_datatable_metadata_input(
+        DATA_VALID,
+        active_cell,
+        DATA_ORIGINAL,
+    )
 
     assert state.metadata.variables_lookup["pers_id"].variable_role == "IDENTIFIER"
     assert output[0] == DATA_VALID
@@ -84,7 +94,11 @@ def test_accept_variable_metadata_clear_string(
     active_cell: dict[str, MetadataInputTypes],
 ):
     state.metadata = metadata
-    output = accept_variable_metadata_input(DATA_CLEAR_URI, active_cell, DATA_ORIGINAL)
+    output = accept_variable_datatable_metadata_input(
+        DATA_CLEAR_URI,
+        active_cell,
+        DATA_ORIGINAL,
+    )
 
     assert state.metadata.variables_lookup["pers_id"].definition_uri is None
     assert output[0] == DATA_CLEAR_URI
@@ -98,7 +112,11 @@ def test_accept_variable_metadata_input_incorrect_data_type(
 ):
     state.metadata = metadata
     previous_metadata = deepcopy(state.metadata.meta.variables)
-    output = accept_variable_metadata_input(DATA_INVALID, active_cell, DATA_ORIGINAL)
+    output = accept_variable_datatable_metadata_input(
+        DATA_INVALID,
+        active_cell,
+        DATA_ORIGINAL,
+    )
 
     assert output[0] == DATA_ORIGINAL
     assert output[1] is True
@@ -160,7 +178,7 @@ def test_nonetype_value_for_language_string(
     state.metadata = metadata
     state.metadata.variables_lookup["pers_id"].name = language_object
     state.current_metadata_language = SupportedLanguages.NORSK_NYNORSK
-    accept_variable_metadata_input(DATA_NONETYPE, active_cell, DATA_ORIGINAL)
+    accept_variable_datatable_metadata_input(DATA_NONETYPE, active_cell, DATA_ORIGINAL)
 
     assert state.metadata.variables_lookup["pers_id"].name == language_object
 


### PR DESCRIPTION
## Changes

- Save values to the model
- Display alert on validation error

## Limitations

We have not implemented debounce for the SSB Input component so some fields (for example URL) show many validation alerts.

## Screenshots

Validation errors are shown in the editing area for the relevant variable:
![Screenshot 2024-02-28 at 10 13 03](https://github.com/statisticsnorway/datadoc/assets/42948872/8850762a-2d93-4128-bb7b-ef21531e7300)

Example of data saved to the metadata file:
![Screenshot 2024-02-28 at 10 13 53](https://github.com/statisticsnorway/datadoc/assets/42948872/2c6e9ca7-63dc-42b1-9192-aef68ce6aedc)

Ref: DPMETA-93
