### PR TITLE
Use a Checkbox for DPI

### DIFF
--- a/src/datadoc/frontend/components/resources_test_new_variables.py
+++ b/src/datadoc/frontend/components/resources_test_new_variables.py
@@ -39,11 +39,12 @@ def build_input_field_section(
                 )
                 if i.component == ssb.Input
                 else i.component(
-                    className="variables-input",
                     id={
                         "type": VARIABLES_METADATA_INPUT,
+                        "variable_short_name": variable_short_name,
                         "id": i.identifier,
                     },
+                    **i.extra_kwargs,
                 )
             )
             for i in metadata_inputs

--- a/src/datadoc/frontend/fields/display_new_variables.py
+++ b/src/datadoc/frontend/fields/display_new_variables.py
@@ -6,6 +6,7 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING
 
+import dash_bootstrap_components as dbc
 import ssb_dash_components as ssb  # type: ignore[import-untyped]
 
 from datadoc import state
@@ -88,7 +89,7 @@ DISPLAY_VARIABLES: dict[VariableIdentifiers, DisplayNewVariablesMetadata] = {
         presentation="text",
         component=ssb.Input,
     ),
-    VariableIdentifiers.DATA_TYPE: DisplayNewVariablesMetadata(
+    VariableIdentifiers.DATA_TYPE: DisplayNewVariablesMetadataDropdown(
         identifier=VariableIdentifiers.DATA_TYPE.value,
         display_name="Datatype",
         description="Datatype",
@@ -96,7 +97,7 @@ DISPLAY_VARIABLES: dict[VariableIdentifiers, DisplayNewVariablesMetadata] = {
         presentation="dropdown",
         component=ssb.Dropdown,
     ),
-    VariableIdentifiers.VARIABLE_ROLE: DisplayNewVariablesMetadata(
+    VariableIdentifiers.VARIABLE_ROLE: DisplayNewVariablesMetadataDropdown(
         identifier=VariableIdentifiers.VARIABLE_ROLE.value,
         display_name="Variabelens rolle",
         description="Variabelens rolle i datasett",
@@ -118,8 +119,12 @@ DISPLAY_VARIABLES: dict[VariableIdentifiers, DisplayNewVariablesMetadata] = {
         display_name="DPI",
         description="Direkte personidentifiserende informasjon (DPI)",
         obligatory=True,
-        presentation="dropdown",
-        component=ssb.Dropdown,
+        component=dbc.Checkbox,
+        extra_kwargs={
+            "label": "Direkte Personidentifiserende Informasjon",
+            "label_class_name": "ssb-checkbox checkbox-label",
+            "class_name": "ssb-checkbox",
+        },
     ),
     VariableIdentifiers.DATA_SOURCE: DisplayNewVariablesMetadata(
         identifier=VariableIdentifiers.DATA_SOURCE.value,


### PR DESCRIPTION
## Description

This felt like the most intuitive component to use. Styled with SSBs CSS classes. This works natively to save the boolean value to the model.

## Screenshot

![Screenshot 2024-02-29 at 11 42 07](https://github.com/statisticsnorway/datadoc/assets/42948872/29f9c61f-1fa8-484d-b957-f980cefcf53c)

Ref: DPMETA-96