### PR TITLE
Change name in norwegian for protected

### DIFF
--- a/src/datadoc/enums.py
+++ b/src/datadoc/enums.py
@@ -84,8 +84,8 @@ class Assessment(LanguageStringsEnum):
     )
     PROTECTED = LanguageStringType(
         en=model.Assessment.PROTECTED.value,
-        nn="BESKYTTET",
-        nb="BESKYTTET",
+        nn="SKJERMET",
+        nb="SKJERMET",
     )
     OPEN = LanguageStringType(en=model.Assessment.OPEN.value, nn="ÅPEN", nb="ÅPEN")
 


### PR DESCRIPTION
Changed name from "beskyttet" to "skjermet" in norwegian/nynorsk
"Skjermet" is probably not correct 'nynorsk'.