### PR TITLE
Correct categorisation of dataset fields

### DIFF
--- a/src/datadoc/frontend/fields/display_dataset.py
+++ b/src/datadoc/frontend/fields/display_dataset.py
@@ -135,6 +135,7 @@ DISPLAY_DATASET: dict[DatasetIdentifiers, DisplayDatasetMetadata] = {
             get_enum_options_for_language,
             enums.DataSetStatus,
         ),
+        obligatory=True,
     ),
     DatasetIdentifiers.DATASET_STATE: DisplayDatasetMetadataDropdown(
         identifier=DatasetIdentifiers.DATASET_STATE.value,
@@ -185,6 +186,7 @@ DISPLAY_DATASET: dict[DatasetIdentifiers, DisplayDatasetMetadata] = {
         display_name="Versjonsbeskrivelse",
         description="Årsak/grunnlag for denne versjonen av datasettet i form av beskrivende tekst.",
         multiple_language_support=True,
+        obligatory=True,
     ),
     DatasetIdentifiers.UNIT_TYPE: DisplayDatasetMetadataDropdown(
         identifier=DatasetIdentifiers.UNIT_TYPE.value,
@@ -192,6 +194,7 @@ DISPLAY_DATASET: dict[DatasetIdentifiers, DisplayDatasetMetadata] = {
         description="Primær enhetstype for datafil, datatabell eller datasett. Se  Vi jobber med en avklaring av behov for flere enhetstyper her.",
         multiple_language_support=False,
         options_getter=get_unit_type_options,
+        obligatory=True,
     ),
     DatasetIdentifiers.TEMPORALITY_TYPE: DisplayDatasetMetadataDropdown(
         identifier=DatasetIdentifiers.TEMPORALITY_TYPE.value,
@@ -201,12 +204,14 @@ DISPLAY_DATASET: dict[DatasetIdentifiers, DisplayDatasetMetadata] = {
             get_enum_options_for_language,
             enums.TemporalityTypeType,
         ),
+        obligatory=True,
     ),
     DatasetIdentifiers.DESCRIPTION: DisplayDatasetMetadata(
         identifier=DatasetIdentifiers.DESCRIPTION.value,
         display_name="Beskrivelse",
         description="Beskrivelse av datasettet",
         multiple_language_support=True,
+        obligatory=True,
     ),
     DatasetIdentifiers.SUBJECT_FIELD: DisplayDatasetMetadataDropdown(
         identifier=DatasetIdentifiers.SUBJECT_FIELD.value,

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -77,7 +77,7 @@ def test_metadata_document_percent_complete(metadata: DataDocMetadata):
     metadata.dataset = document.dataset  # type: ignore [assignment]
     metadata.variables = document.variables  # type: ignore [assignment]
 
-    assert metadata.percent_complete == 16  # noqa: PLR2004
+    assert metadata.percent_complete == 12  # noqa: PLR2004
 
 
 def test_write_metadata_document(


### PR DESCRIPTION
- Made the fields Dataset Status, Description, Version Description, Unit Type, and Temporality Type to be obligatory
- Updated progress bar test to pass with the above change