### PR TITLE
Use a with block for ThreadPoolExecutor

### DIFF
--- a/src/datadoc/backend/external_sources/external_sources.py
+++ b/src/datadoc/backend/external_sources/external_sources.py
@@ -21,10 +21,10 @@ class GetExternalSource(ABC, Generic[T]):
         Initializes the future object.
         """
         self.future: concurrent.futures.Future[T | None] | None = None
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        self.future = executor.submit(
-            self._fetch_data_from_external_source,
-        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            self.future = executor.submit(
+                self._fetch_data_from_external_source,
+            )
 
     def wait_for_external_result(self) -> None:
         """Waits for the thread responsible for loading the external request to finish."""

--- a/src/datadoc/backend/statistic_subject_mapping.py
+++ b/src/datadoc/backend/statistic_subject_mapping.py
@@ -141,8 +141,9 @@ class StatisticSubjectMapping(GetExternalSource):
     @property
     def primary_subjects(self) -> list[PrimarySubject]:
         """Getter for primary subjects."""
-        self._parse_xml_if_loaded()
-        logger.debug("Got %s primary subjects", len(self._primary_subjects))
+        if not self._primary_subjects:
+            self._parse_xml_if_loaded()
+            logger.debug("Got %s primary subjects", len(self._primary_subjects))
         return self._primary_subjects
 
     def _parse_xml_if_loaded(self) -> bool:


### PR DESCRIPTION
Fixes the [issue reported by Snyk](https://app.snyk.io/org/metadata-4HXc5gFuHL33XrnDhH8QZD/project/65c882c9-450e-4544-ab01-fbfe37a75577#issue-818abb57-cd4b-452a-ab70-97d0c68e12dc)

![Screenshot 2024-03-14 at 09 47 17](https://github.com/statisticsnorway/datadoc/assets/42948872/540ce457-b15e-4dfe-ba14-ab265533f1b4)

Ref: DPMETA-125
