### PR TITLE
Instantiate the thread pool from the outermost layers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,11 @@ To set up for local development run this command from the root of the repo.
 
 1. Create a file `src/datadoc/.env`
 1. Place the following lines in the file:
-```
-DATADOC_DASH_DEVELOPMENT_MODE=True
-DATADOC_LOG_LEVEL=debug
-```
+
+    ```env
+    DATADOC_DASH_DEVELOPMENT_MODE=True
+    DATADOC_LOG_LEVEL=debug
+    ```
 
 To see all configuration options, see `src/datadoc/config.py`
 

--- a/src/datadoc/backend/code_list.py
+++ b/src/datadoc/backend/code_list.py
@@ -8,6 +8,8 @@ from datadoc.backend.external_sources.external_sources import GetExternalSource
 from datadoc.enums import SupportedLanguages
 
 if TYPE_CHECKING:
+    import concurrent
+
     import pandas as pd
 
 from klass.classes.classification import KlassClassification
@@ -51,7 +53,11 @@ class CodeListItem:
 class CodeList(GetExternalSource):
     """Class for retrieving classifications from Klass."""
 
-    def __init__(self, classification_id: int | None) -> None:
+    def __init__(
+        self,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        classification_id: int | None,
+    ) -> None:
         """Retrieves a list of classifications given a classification id.
 
         Initializes the classifications list and starts fetching the classifications.
@@ -63,7 +69,7 @@ class CodeList(GetExternalSource):
         self._classifications: list[CodeListItem] = []
         self.classification_id = classification_id
         self.classifications_dataframes: dict[str, pd.DataFrame] | None = None
-        super().__init__()
+        super().__init__(executor)
 
     def _fetch_data_from_external_source(
         self,

--- a/src/datadoc/backend/external_sources/external_sources.py
+++ b/src/datadoc/backend/external_sources/external_sources.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 from abc import ABC
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Generic
 from typing import TypeVar
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 logger = logging.getLogger(__name__)
 
@@ -15,16 +18,14 @@ T = TypeVar("T")
 class GetExternalSource(ABC, Generic[T]):
     """Abstract base class for getting data from external sources."""
 
-    def __init__(self) -> None:
+    def __init__(self, executor: concurrent.futures.ThreadPoolExecutor) -> None:
         """Retrieves data from an external source asynchronously.
 
         Initializes the future object.
         """
-        self.future: concurrent.futures.Future[T | None] | None = None
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            self.future = executor.submit(
-                self._fetch_data_from_external_source,
-            )
+        self.future = executor.submit(
+            self._fetch_data_from_external_source,
+        )
 
     def wait_for_external_result(self) -> None:
         """Waits for the thread responsible for loading the external request to finish."""

--- a/src/datadoc/backend/statistic_subject_mapping.py
+++ b/src/datadoc/backend/statistic_subject_mapping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import bs4
 import requests
@@ -10,6 +11,9 @@ from bs4 import ResultSet
 
 from datadoc.backend.external_sources.external_sources import GetExternalSource
 from datadoc.enums import SupportedLanguages
+
+if TYPE_CHECKING:
+    import concurrent
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +66,11 @@ class PrimarySubject(Subject):
 class StatisticSubjectMapping(GetExternalSource):
     """Allow mapping between statistic short name and primary and secondary subject."""
 
-    def __init__(self, source_url: str | None) -> None:
+    def __init__(
+        self,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        source_url: str | None,
+    ) -> None:
         """Retrieves the statistical structure document from the given URL.
 
         Initializes the mapping dicts. Based on the values in the statistical structure document.
@@ -73,7 +81,7 @@ class StatisticSubjectMapping(GetExternalSource):
 
         self._primary_subjects: list[PrimarySubject] = []
 
-        super().__init__()
+        super().__init__(executor)
 
     def get_secondary_subject(self, statistic_short_name: str | None) -> str | None:
         """Looks up the secondary subject for the given statistic short name in the mapping dict.

--- a/src/datadoc/wsgi.py
+++ b/src/datadoc/wsgi.py
@@ -1,6 +1,9 @@
 """Entrypoint for Gunicorn."""
 
+import concurrent
+
 from .app import get_app
 
-datadoc_app, _ = get_app()
-server = datadoc_app.server
+with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
+    datadoc_app, _ = get_app(executor)
+    server = datadoc_app.server

--- a/tests/backend/test_code_list.py
+++ b/tests/backend/test_code_list.py
@@ -125,7 +125,7 @@ def test_read_dataframe(
     assert code_list_fake_structure.classifications == expected
 
 
-def test_non_existent_code():
-    code_list = CodeList(0)
+def test_non_existent_code(thread_pool_executor):
+    code_list = CodeList(thread_pool_executor, 0)
     code_list.wait_for_external_result()
     assert code_list.classifications == []

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -314,9 +314,13 @@ def test_dataset_status_default_value(
 def test_dataset_assessment_default_value(
     expected_type: Assessment | None,
     copy_dataset_to_path: Path,
+    thread_pool_executor,
 ):
     datadoc_metadata = DataDocMetadata(
-        statistic_subject_mapping=StatisticSubjectMapping(source_url=""),
+        statistic_subject_mapping=StatisticSubjectMapping(
+            thread_pool_executor,
+            source_url="",
+        ),
         dataset_path=str(copy_dataset_to_path),
     )
     assert datadoc_metadata.dataset.assessment == expected_type

--- a/tests/backend/test_statistic_subject_mapping.py
+++ b/tests/backend/test_statistic_subject_mapping.py
@@ -8,8 +8,8 @@ from datadoc.backend.statistic_subject_mapping import StatisticSubjectMapping
 from tests.utils import TEST_RESOURCES_DIRECTORY
 
 
-def test_no_source_url():
-    subject_mapping = StatisticSubjectMapping(None)
+def test_no_source_url(thread_pool_executor):
+    subject_mapping = StatisticSubjectMapping(thread_pool_executor, None)
     subject_mapping.wait_for_external_result()
     assert subject_mapping.primary_subjects == []
 
@@ -151,12 +151,13 @@ def test_get_secondary_subject(
 def subject_mapping_http_exception(
     requests_mock,
     exception_to_raise,
+    thread_pool_executor,
 ) -> StatisticSubjectMapping:
     requests_mock.get(
         "http://test.some.url.com",
         exc=exception_to_raise,
     )
-    return StatisticSubjectMapping("http://test.some.url.com")
+    return StatisticSubjectMapping(thread_pool_executor, "http://test.some.url.com")
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent
 import copy
 import functools
 import os
@@ -170,10 +171,16 @@ def subject_xml_file_path() -> pathlib.Path:
 
 
 @pytest.fixture()
+def thread_pool_executor() -> concurrent.futures.ThreadPoolExecutor:
+    return concurrent.futures.ThreadPoolExecutor(max_workers=12)
+
+
+@pytest.fixture()
 def subject_mapping_fake_statistical_structure(
     _mock_fetch_statistical_structure,
+    thread_pool_executor,
 ) -> StatisticSubjectMapping:
-    return StatisticSubjectMapping("placeholder")
+    return StatisticSubjectMapping(thread_pool_executor, "placeholder")
 
 
 @pytest.fixture()
@@ -195,12 +202,13 @@ def _mock_fetch_statistical_structure(
 def subject_mapping_http_exception(
     requests_mock,
     exception_to_raise,
+    thread_pool_executor,
 ) -> StatisticSubjectMapping:
     requests_mock.get(
         "http://test.some.url.com",
         exc=exception_to_raise,
     )
-    return StatisticSubjectMapping("http://test.some.url.com")
+    return StatisticSubjectMapping(thread_pool_executor, "http://test.some.url.com")
 
 
 @pytest.fixture()
@@ -239,10 +247,8 @@ def _mock_fetch_dataframe(
 
 
 @pytest.fixture()
-def code_list_fake_structure(
-    _mock_fetch_dataframe,
-) -> CodeList:
-    return CodeList(100)
+def code_list_fake_structure(_mock_fetch_dataframe, thread_pool_executor) -> CodeList:
+    return CodeList(thread_pool_executor, 100)
 
 
 @pytest.fixture()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,10 +4,14 @@ from datadoc import state
 from datadoc.app import get_app
 
 
-def test_get_app(subject_mapping_fake_statistical_structure, code_list_fake_structure):
+def test_get_app(
+    subject_mapping_fake_statistical_structure,
+    code_list_fake_structure,
+    thread_pool_executor,
+):
     state.statistic_subject_mapping = subject_mapping_fake_statistical_structure
     state.code_list = code_list_fake_structure
 
-    app, _ = get_app()
+    app, _ = get_app(thread_pool_executor)
     assert app.config["name"] == "Datadoc"
     assert len(app.callback_map.items()) > 0


### PR DESCRIPTION
Using a `with` block for `ThreadPoolExecutor` is blocking, since all threads need to be finished to close the thread pool. This moves the `with` block outside app startup such that closing the thread pool occurs on app shutdown.

Ref: DPMETA-125