### PR TITLE
User can deselect selected option 

### DIFF
--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -91,6 +91,8 @@ def accept_variable_metadata_input(
         )
         return str(e)
     else:
+        if value == "":
+            value = None
         logger.debug(
             "Successfully updated %s, %s with %s",
             metadata_field,

--- a/src/datadoc/frontend/fields/display_base.py
+++ b/src/datadoc/frontend/fields/display_base.py
@@ -47,13 +47,15 @@ def get_enum_options_for_language(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
     """Generate the list of options based on the currently chosen language."""
-    return [
+    dropdown_options = [
         {
             "title": i.get_value_for_language(language),
             "id": i.name,
         }
         for i in get_language_strings_enum(enum)  # type: ignore [attr-defined]
     ]
+    dropdown_options.insert(0, {"title": "", "id": ""})
+    return dropdown_options
 
 
 def input_kwargs_factory() -> dict[str, t.Any]:

--- a/src/datadoc/frontend/fields/display_dataset.py
+++ b/src/datadoc/frontend/fields/display_dataset.py
@@ -30,20 +30,22 @@ def get_enum_options_for_language(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
     """Generate the list of options based on the currently chosen language."""
-    return [
+    dropdown_options = [
         {
             "label": i.get_value_for_language(language),
             "value": i.name,
         }
         for i in get_language_strings_enum(enum)  # type: ignore [attr-defined]
     ]
+    dropdown_options.insert(0, {"label": "", "value": ""})
+    return dropdown_options
 
 
 def get_statistical_subject_options(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
-    """Collect the statistical subject options for the given language."""
-    return [
+    """Generate the list of options for statistical subject."""
+    dropdown_options = [
         {
             "label": f"{primary.get_title(language)} - {secondary.get_title(language)}",
             "value": secondary.subject_code,
@@ -51,32 +53,38 @@ def get_statistical_subject_options(
         for primary in state.statistic_subject_mapping.primary_subjects
         for secondary in primary.secondary_subjects
     ]
+    dropdown_options.insert(0, {"label": "", "value": ""})
+    return dropdown_options
 
 
 def get_unit_type_options(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
     """Collect the unit type options for the given language."""
-    return [
+    dropdown_options = [
         {
             "label": unit_type.get_title(language),
             "value": unit_type.code,
         }
         for unit_type in state.unit_types.classifications
     ]
+    dropdown_options.insert(0, {"label": "", "value": ""})
+    return dropdown_options
 
 
 def get_owner_options(
     language: SupportedLanguages,
 ) -> list[dict[str, str]]:
     """Collect the owner options for the given language."""
-    return [
+    dropdown_options = [
         {
             "label": f"{option.code} - {option.get_title(language)}",
             "value": option.code,
         }
         for option in state.organisational_units.classifications
     ]
+    dropdown_options.insert(0, {"label": "", "value": ""})
+    return dropdown_options
 
 
 class DatasetIdentifiers(str, Enum):

--- a/tests/frontend/callbacks/test_dataset_callbacks.py
+++ b/tests/frontend/callbacks/test_dataset_callbacks.py
@@ -260,15 +260,15 @@ def test_change_language_dataset_metadata_options_enums(
 
         member_names = {m.name for m in enum_for_options}  # type: ignore [attr-defined]
         values = [i for d in options for i in d.values()]
-
+        test_without_empty_option = options[1:]
         if member_names.intersection(values):
-            assert {d["label"] for d in options} == {
+            assert {d["label"] for d in test_without_empty_option} == {
                 e.get_value_for_language(
                     language,
                 )
                 for e in enum_for_options  # type: ignore [attr-defined]
             }
-            assert {d["value"] for d in options} == {e.name for e in enum_for_options}  # type: ignore [attr-defined]
+            assert {d["value"] for d in test_without_empty_option} == {e.name for e in enum_for_options}  # type: ignore [attr-defined]
 
 
 @patch(f"{DATASET_CALLBACKS_MODULE}.open_file")

--- a/tests/frontend/fields/test_display_dataset.py
+++ b/tests/frontend/fields/test_display_dataset.py
@@ -19,6 +19,7 @@ from tests.utils import TEST_RESOURCES_DIRECTORY
             / STATISTICAL_SUBJECT_STRUCTURE_DIR
             / "extract_secondary_subject.xml",
             [
+                {"label": "", "value": ""},
                 {"label": "aa norwegian - aa00 norwegian", "value": "aa00"},
                 {"label": "aa norwegian - aa01 norwegian", "value": "aa01"},
                 {"label": "ab norwegian - ab00 norwegian", "value": "ab00"},
@@ -30,6 +31,7 @@ from tests.utils import TEST_RESOURCES_DIRECTORY
             / STATISTICAL_SUBJECT_STRUCTURE_DIR
             / "missing_language.xml",
             [
+                {"label": "", "value": ""},
                 {"label": " - aa00 norwegian", "value": "aa00"},
                 {"label": " - aa01 norwegian", "value": "aa01"},
                 {"label": " - ab00 norwegian", "value": "ab00"},
@@ -53,6 +55,7 @@ def test_get_statistical_subject_options(
         (
             TEST_RESOURCES_DIRECTORY / CODE_LIST_DIR / "code_list_nb.csv",
             [
+                {"label": "", "value": ""},
                 {"label": "Adresse", "value": "01"},
                 {"label": "Arbeidsulykke", "value": "02"},
                 {"label": "Bolig", "value": "03"},


### PR DESCRIPTION
- Add empty option in all dropdown lists
- Empty option value is empty string
- logger message in callbacks: if value is "", value is None - to ensure a logic message when updated with empty string value
- Update tests in test_display_dataset: add empty option in lists
- Update test in test_dataset_callback: remove empty option in comparison with enum options