### PR TITLE
fix datetime format variables for display date

### DIFF
--- a/src/datadoc/frontend/fields/display_base.py
+++ b/src/datadoc/frontend/fields/display_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import typing as t
 from dataclasses import dataclass
 from dataclasses import field
@@ -95,12 +96,21 @@ def get_date_metadata_and_stringify(metadata: BaseModel, identifier: str) -> str
     Handle converting datetime format to date format string.
     """
     value = get_standard_metadata(metadata, identifier)
+    if value is None:
+        return ""
     logger.info("Date registered: %s", value)
-    if isinstance(value, str):
-        convert_value = value[:10]
-        logger.info("Converted date: %s", convert_value)
-        return convert_value
-    return None
+    date = str(value)
+    # Pattern for datetime without T, with space - used for variables
+    pattern = r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}"
+    if re.match(pattern, date):
+        convert_date_to_iso = date.replace(" ", "T")
+        logger.info("Date converted to iso format: %s", convert_date_to_iso)
+        convert_date_format = convert_date_to_iso[:10]
+        logger.info("Display date: %s", convert_date_format)
+        return convert_date_format
+    convert_value = date[:10]
+    logger.info("Display date: %s", convert_value)
+    return convert_value
 
 
 def get_multi_language_metadata(metadata: BaseModel, identifier: str) -> str | None:


### PR DESCRIPTION
Dates in Dataset and Variables are processed differently. 
Dataset dates are iso-format, Variables dates has space between date and time. 
This solution solves the issue with variables dates not being displayed.