### PR TITLE
Use correct value for dataset short_name

### DIFF
--- a/src/datadoc/backend/datadoc_metadata.py
+++ b/src/datadoc/backend/datadoc_metadata.py
@@ -53,7 +53,6 @@ class DataDocMetadata:
         self.metadata_document: pathlib.Path | CloudPath | None = None
         self.container: model.MetadataContainer | None = None
         self.dataset_path: pathlib.Path | CloudPath | None = None
-        self.short_name: str | None = None
         self.dataset = model.Dataset()
         self.variables: list = []
         self.variables_lookup: dict[str, model.Variable] = {}
@@ -176,7 +175,7 @@ class DataDocMetadata:
         )
 
         self.dataset = model.Dataset(
-            short_name=self.dataset_path.stem if self.dataset_path else None,
+            short_name=dapla_dataset_path_info.dataset_short_name,
             dataset_state=dapla_dataset_path_info.dataset_state,
             dataset_status=DataSetStatus.DRAFT,
             assessment=self.get_assessment_by_state(

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -177,6 +177,10 @@ def test_existing_metadata_valid_id(
     assert post_write_id == pre_open_id
 
 
+def test_dataset_short_name(metadata: DataDocMetadata):
+    assert metadata.dataset.short_name == "person_data"
+
+
 def test_variable_role_default_value(metadata: DataDocMetadata):
     assert all(
         v.variable_role == VariableRole.MEASURE.value for v in metadata.variables


### PR DESCRIPTION
Given a file name `person_testdata_p2021-12-31_p2021-12-31_v1.parquet` we were saving the short name as `person_testdata_p2021-12-31_p2021-12-31_v1`. This is longer than it should be, the short name is defined to be the part of the file name before the period and/or version information. This PR corrects this such that the short name in the given example would be `person_testdata`.

Ref: DPMETA-106