### PR TITLE
Add glossary to dropdown

### DIFF
--- a/src/datadoc/assets/workspace_style.css
+++ b/src/datadoc/assets/workspace_style.css
@@ -85,3 +85,23 @@
 label.form-check-label{
     padding-left: 0.5rem;
 }
+
+.dropdown-wrapper > .ssb-glossary.info-glossary > .glossary-popup {
+    margin-left: 20px;
+    left: unset;
+    top: unset;
+    bottom: 5px;
+}
+
+.dropdown-wrapper > .ssb-glossary.info-glossary > .glossary-popup::after {
+    left: -10px;
+    margin-left: -10px;
+    top: unset;
+    bottom: 5px;
+    transform: rotateX(-90deg);
+    -webkit-transform: rotate(-90deg);
+}
+
+.ssb-glossary.datadoc-glossary > .glossary-popup .content-box > .glossary-closing{
+    margin-top: 1.8rem;
+}

--- a/src/datadoc/frontend/fields/display_base.py
+++ b/src/datadoc/frontend/fields/display_base.py
@@ -160,6 +160,7 @@ class MetadataInputField(DisplayMetadata):
 class MetadataDropdownField(DisplayMetadata):
     """Control how a Dropdown should be displayed."""
 
+    show_description: bool = True
     extra_kwargs: dict[str, Any] = field(default_factory=empty_kwargs_factory)
     value_getter: Callable[[BaseModel, str], Any] = get_metadata_and_stringify
     # fmt: off
@@ -180,6 +181,8 @@ class MetadataDropdownField(DisplayMetadata):
             items=self.options_getter(SupportedLanguages(language)),
             value=value,
             className="dropdown-component",
+            showDescription=self.show_description,
+            description=self.description,
         )
 
 

--- a/src/datadoc/frontend/fields/display_dataset.py
+++ b/src/datadoc/frontend/fields/display_dataset.py
@@ -117,6 +117,7 @@ DISPLAY_DATASET: dict[
         identifier=DatasetIdentifiers.ASSESSMENT.value,
         display_name="Verdivurdering",
         description="Verdivurdering (sensitivitetsklassifisering) for datasettet.",
+        show_description=False,
         options_getter=functools.partial(
             get_enum_options_for_language,
             enums.Assessment,


### PR DESCRIPTION
- Add updated Dropdown component with glossary above Header text for now until we either solve the issue ourself in ssb-dash-components or SSB component library is updated with glossary 
- Prop description send in an explanation text to Glossary, description text is retrieved from VariableIdentifiers and DatasetIdentifiers class
- Prop showDescription on Dropdown and show_description on MetadataDropdownField class enables control over which descriptions we show
