### PR TITLE
Deploy to NAIS on PR

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: "write"
     runs-on: ubuntu-latest
     outputs:
-      image-tag: ${{ steps.metadata.outputs.tags }}
+      image-tag: ${{ steps.metadata.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "src/datadoc/**"
       - "poetry.lock"
-      - ".nais/nais.yaml"
+      - ".nais/staging-pr.yaml"
       - ".github/workflows/integration-test.yml"
 
 env:
@@ -83,6 +83,6 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: staging
-          RESOURCE: .nais/nais.yaml
+          RESOURCE: .nais/staging-pr.yaml
           VAR: image=${{ needs.docker-build.outputs.image-tag }},pr-number=${{github.event.number}}
           DEPLOY_SERVER: deploy.ssb.cloud.nais.io:443

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/datadoc/**"
       - "poetry.lock"
+      - ".nais/nais.yaml"
       - ".github/workflows/integration-test.yml"
 
 env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,90 @@
+name: Integration test
+
+on:
+  push:
+    paths:
+      - "src/datadoc/**"
+      - "poetry.lock"
+      - ".github/workflows/integration-test.yml"
+
+env:
+  REGISTRY: europe-north1-docker.pkg.dev/nais-management-b3a7/dapla-metadata/datadoc
+  IMAGE: datadoc
+  TAG: ${{ github.head_ref }}-${{ github.sha }}
+
+jobs:
+  docker-build:
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.metadata.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Authenticate to Google Cloud"
+        id: "auth"
+        uses: "google-github-actions/auth@v2.1.2"
+        with:
+          workload_identity_provider: "projects/906675412832/locations/global/workloadIdentityPools/ssb-identity-pool/providers/github-oidc-provider"
+          service_account: "gh-ssb@nais-management-b3a7.iam.gserviceaccount.com"
+          token_format: "access_token"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
+
+      - name: Docker meta
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          # Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=${{ env.TAG }}, enable=true
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
+      - name: Output image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  deploy:
+    name: Deploy to NAIS
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: staging
+          RESOURCE: .nais/nais.yaml
+          VAR: image=${{ needs.docker-build.outputs.image-tag }}
+          DEPLOY_SERVER: deploy.ssb.cloud.nais.io:443

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,7 @@
 name: Integration test
 
 on:
-  push:
+  pull_request:
     paths:
       - "src/datadoc/**"
       - "poetry.lock"
@@ -10,10 +10,11 @@ on:
 env:
   REGISTRY: europe-north1-docker.pkg.dev/nais-management-b3a7/dapla-metadata/datadoc
   IMAGE: datadoc
-  TAG: ${{ github.ref_name }}-${{ github.sha }}
+  TAG: ${{ github.head_ref }}-${{ github.sha }}
 
 jobs:
   docker-build:
+    name: Docker build
     permissions:
       contents: "read"
       id-token: "write"
@@ -80,11 +81,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: nais/deploy/actions/deploy@v2
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: staging
           RESOURCE: .nais/nais.yaml
-          VAR: image=${{ needs.docker-build.outputs.image-tag }}
+          VAR: image=${{ needs.docker-build.outputs.image-tag }},pr-number=${{github.event.number}}
           DEPLOY_SERVER: deploy.ssb.cloud.nais.io:443

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,11 +54,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
-            type=schedule
-            type=ref,event=branch
             type=ref,event=pr
-            type=sha
-            type=raw,value=${{ env.TAG }}, enable=true
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: europe-north1-docker.pkg.dev/nais-management-b3a7/dapla-metadata/datadoc
   IMAGE: datadoc
-  TAG: ${{ github.head_ref }}-${{ github.sha }}
+  TAG: ${{ github.ref_name }}-${{ github.sha }}
 
 jobs:
   docker-build:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/integration-test.yml"
 
 env:
-  REGISTRY: europe-north1-docker.pkg.dev/nais-management-b3a7/dapla-metadata/datadoc
+  REGISTRY: europe-north1-docker.pkg.dev/nais-management-b3a7/dapla-metadata
   IMAGE: datadoc
   TAG: ${{ github.head_ref }}-${{ github.sha }}
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -55,7 +55,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
-            type=ref,event=pr
+            type=sha
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: "write"
     runs-on: ubuntu-latest
     outputs:
-      image-tag: ${{ steps.metadata.outputs.tag }}
+      image-tag: ${{ steps.metadata.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -1,7 +1,7 @@
 apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
-  name: datadoc-pr-{{branch}}
+  name: datadoc-pr-{{ pr-number }}
   namespace: dapla-metadata
   annotations:
     nais.io/read-only-file-system: "false"
@@ -36,4 +36,4 @@ spec:
     enabled: false
 
   ingresses:
-    - https://datadoc-{{branch}}.internal.staging.ssb.cloud.nais.io
+    - https://datadoc-pr-{{ pr-number }}.internal.staging.ssb.cloud.nais.io

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -16,7 +16,7 @@ spec:
     disableAutoScaling: true
     max: 1
     min: 1
-  port: 8080
+  port: 8050
 
   accessPolicy:
     outbound:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -36,4 +36,4 @@ spec:
     enabled: false
 
   ingresses:
-    - https://datadoc-pr-{{ pr-number }}.internal.staging.ssb.cloud.nais.io
+    - https://datadoc-pr-{{ pr-number }}.staging.ssb.cloud.nais.io

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -3,9 +3,6 @@ kind: Application
 metadata:
   name: datadoc-pr-{{ pr-number }}
   namespace: dapla-metadata
-  annotations:
-    nais.io/read-only-file-system: "false"
-    nais.io/run-as-user: "1337"
   labels:
     team: dapla-metadata
 spec:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -6,14 +6,13 @@ metadata:
   labels:
     team: dapla-metadata
 spec:
-  image: "{{ image }}"
-  #       ^--- interpolated from the variable in the action
+  image: "{{ image }}"  # Injected from the Github Action
+  port: 8050
 
   replicas:
     disableAutoScaling: true
     max: 1
     min: 1
-  port: 8050
 
   accessPolicy:
     outbound:
@@ -34,3 +33,13 @@ spec:
 
   ingresses:
     - https://datadoc-pr-{{ pr-number }}.staging.ssb.cloud.nais.io
+
+  liveness:
+    path: /healthz/live
+    port: 8050
+  readiness:
+    path: /healthz/ready
+    port: 8050
+  startup:
+    path: /healthz/startup
+    port: 8050

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -1,0 +1,39 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+metadata:
+  name: datadoc-pr-{{branch}}
+  namespace: dapla-metadata
+  annotations:
+    nais.io/read-only-file-system: "false"
+    nais.io/run-as-user: "1337"
+  labels:
+    team: dapla-metadata
+spec:
+  image: "{{ image }}"
+  #       ^--- interpolated from the variable in the action
+
+  replicas:
+    disableAutoScaling: true
+    max: 1
+    min: 1
+  port: 8080
+
+  accessPolicy:
+    outbound:
+      external:
+        - host: data.ssb.no
+        - host: www.ssb.no
+
+  resources:
+    limits:
+      memory: 2Gi
+    requests:
+      memory: 1Gi
+
+  ttl: 1h
+
+  prometheus:
+    enabled: false
+
+  ingresses:
+    - https://datadoc-{{branch}}.internal.staging.ssb.cloud.nais.io

--- a/.nais/staging-pr.yaml
+++ b/.nais/staging-pr.yaml
@@ -1,3 +1,5 @@
+# Deploy to staging environment for an individual PR
+
 apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ ENV \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100
 
-RUN useradd --create-home appuser
-USER appuser
-ENV PATH="/home/appuser/.local/bin:$PATH"
+# RUN useradd --create-home appuser
+# USER appuser
+# ENV PATH="/home/appuser/.local/bin:$PATH"
 
 # export environment variables for the CMD
 ENV PACKAGE_NAME=$PACKAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,6 @@ ENV \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100
 
-# RUN useradd --create-home appuser
-# USER appuser
-# ENV PATH="/home/appuser/.local/bin:$PATH"
-
 # export environment variables for the CMD
 ENV PACKAGE_NAME=$PACKAGE_NAME
 ENV APP_PATH=$APP_PATH


### PR DESCRIPTION
## Summary

- Enable running integration tests on PR by deploying datadoc to nais when a PR is opened
- Build and push the Docker image to the Nais Artifact Registry
- Deploy to nais staging using the built image
- The app will be available for 1 hour before being deleted
- Status may be viewed on the console: https://console.ssb.cloud.nais.io/team/dapla-metadata/staging/app/datadoc-pr-281 (Requires naisdevice connection)
- The app will be available on URL with format https://datadoc-pr-281.staging.ssb.cloud.nais.io/ (Requires naisdevice connection)

## Remaining work

- Make a dataset available for use in app

## Screenshots

![Screenshot 2024-04-11 at 10 24 22](https://github.com/statisticsnorway/datadoc/assets/42948872/6096fd39-7c7e-4bcd-a8fb-6bff6aaba390)


## Reference

DPMETA-177