### PR TITLE
Fix value refresh in dataset workspace

### DIFF
--- a/src/datadoc/frontend/callbacks/register_callbacks.py
+++ b/src/datadoc/frontend/callbacks/register_callbacks.py
@@ -15,7 +15,6 @@ from dash import Input
 from dash import Output
 from dash import State
 from dash import ctx
-from dash import no_update
 
 from datadoc import state
 from datadoc.enums import SupportedLanguages
@@ -162,7 +161,7 @@ def register_callbacks(app: Dash) -> None:
     @app.callback(
         Output(SECTION_WRAPPER_ID, "children"),
         Input("language-dropdown", "value"),
-        Input("open-button", "n_clicks"),
+        State("open-button", "n_clicks"),
         prevent_initial_call=True,
     )
     def callback_populate_dataset_workspace(
@@ -171,32 +170,40 @@ def register_callbacks(app: Dash) -> None:
     ) -> list:
         """Create dataset workspace with sections."""
         update_global_language_state(SupportedLanguages(language))
+
         logger.debug("Populating dataset workspace")
-        if n_clicks:
-            return [
-                build_dataset_edit_section(
-                    "Obligatorisk",
-                    OBLIGATORY_EDITABLE_DATASET_METADATA,
-                    state.current_metadata_language,
-                    state.metadata.dataset,
-                    {"type": "dataset-edit-section", "id": f"obligatory-{language}"},
-                ),
-                build_dataset_edit_section(
-                    "Anbefalt",
-                    OPTIONAL_DATASET_METADATA,
-                    state.current_metadata_language,
-                    state.metadata.dataset,
-                    {"type": "dataset-edit-section", "id": f"recommended-{language}"},
-                ),
-                build_dataset_edit_section(
-                    "Maskingenerert",
-                    NON_EDITABLE_DATASET_METADATA,
-                    state.current_metadata_language,
-                    state.metadata.dataset,
-                    {"type": "dataset-edit-section", "id": f"machine-{language}"},
-                ),
-            ]
-        return no_update
+        return [
+            build_dataset_edit_section(
+                "Obligatorisk",
+                OBLIGATORY_EDITABLE_DATASET_METADATA,
+                state.current_metadata_language,
+                state.metadata.dataset,
+                {
+                    "type": "dataset-edit-section",
+                    "id": f"obligatory-{language}-{n_clicks}",
+                },
+            ),
+            build_dataset_edit_section(
+                "Anbefalt",
+                OPTIONAL_DATASET_METADATA,
+                state.current_metadata_language,
+                state.metadata.dataset,
+                {
+                    "type": "dataset-edit-section",
+                    "id": f"recommended-{language}-{n_clicks}",
+                },
+            ),
+            build_dataset_edit_section(
+                "Maskingenerert",
+                NON_EDITABLE_DATASET_METADATA,
+                state.current_metadata_language,
+                state.metadata.dataset,
+                {
+                    "type": "dataset-edit-section",
+                    "id": f"machine-{language}-{n_clicks}",
+                },
+            ),
+        ]
 
     @app.callback(
         Output(

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -15,7 +15,7 @@ from datadoc.utils import get_app_version
 COLORS = {"dark_1": "#F0F8F9", "green_1": "#ECFEED", "green_4": "#00824D"}
 
 header = ssb.Header(
-    [ssb.Title("DataDoc", size=1, id="main-title", className="main-title")],
+    [ssb.Title("Datadoc", size=1, id="main-title", className="main-title")],
     className="datadoc-header",
 )
 

--- a/src/datadoc/frontend/fields/display_base.py
+++ b/src/datadoc/frontend/fields/display_base.py
@@ -101,7 +101,7 @@ def get_comma_separated_string(metadata: BaseModel, identifier: str) -> str:
     try:
         return ", ".join(value)
     except TypeError:
-        logger.exception("Type error")
+        # This just means we got None
         return ""
 
 


### PR DESCRIPTION
Values weren't updating when a new dataset was opened. This was broken during work on DPMETA-24.