### PR TITLE
Hover width dropdown glossary

### DIFF
--- a/src/datadoc/assets/input_style.css
+++ b/src/datadoc/assets/input_style.css
@@ -26,6 +26,10 @@ label.form-check-label{
     padding-left: 0.5rem;
 }
 
+.ssb-glossary.info-glossary{
+    max-width: fit-content;
+}
+
 .ssb-input.input-component > span > .ssb-glossary.info-glossary > .glossary-popup {
     margin-left: 20px;
     left: unset;


### PR DESCRIPTION
Span around header was full size and on hover glossary the green backgroundcolor was also full size
Width is now set to fit content and the hover effect is similar to Input component

![Screenshot 2024-04-15 at 12 34 59](https://github.com/statisticsnorway/datadoc/assets/68303562/b03a1bb8-8d2e-4ea7-9416-7ad9756f8635)
