### PR TITLE
Progressbar accessibility

### DIFF
--- a/src/datadoc/assets/progressbar_style.css
+++ b/src/datadoc/assets/progressbar_style.css
@@ -17,5 +17,5 @@ progress::-webkit-progress-bar {
     background-color: #C3DCDC;
  }
  progress::-webkit-progress-value {
-    background-color: #00824D;
+    background-color: #1A9D49;
  }

--- a/src/datadoc/assets/progressbar_style.css
+++ b/src/datadoc/assets/progressbar_style.css
@@ -3,6 +3,7 @@
     height: 1.8rem;
     border-radius: 10px;
     position: relative;
+    background-color: #C3DCDC;
 }
 
 #progress-bar-label{
@@ -17,5 +18,9 @@ progress::-webkit-progress-bar {
     background-color: #C3DCDC;
  }
  progress::-webkit-progress-value {
+    background-color: #1A9D49;
+ }
+
+ progress[value]::-moz-progress-bar{
     background-color: #1A9D49;
  }

--- a/src/datadoc/assets/progressbar_style.css
+++ b/src/datadoc/assets/progressbar_style.css
@@ -1,7 +1,6 @@
 .progress-bar{
     width: 100%;
     height: 1.8rem;
-    border: 4px solid #B6E8B8;
     border-radius: 10px;
     position: relative;
 }
@@ -15,7 +14,7 @@
 
 }
 progress::-webkit-progress-bar {
-    background-color: white;
+    background-color: #C3DCDC;
  }
  progress::-webkit-progress-value {
     background-color: #00824D;

--- a/src/datadoc/assets/progressbar_style.css
+++ b/src/datadoc/assets/progressbar_style.css
@@ -9,9 +9,10 @@
 #progress-bar-label{
     position: absolute;
     top: 145px;
-    left: 20%;
+    left: 25%;
     z-index: 1;
-    color: white;
+    color: #162327;
+    font-weight: 502;
 
 }
 progress::-webkit-progress-bar {

--- a/src/datadoc/assets/utils_style.css
+++ b/src/datadoc/assets/utils_style.css
@@ -1,5 +1,4 @@
 .progress-bar{
-    /*max-width: 800px;*/
     width: 100%;
     height: 1.8rem;
     border: 1px solid #274247;

--- a/src/datadoc/assets/utils_style.css
+++ b/src/datadoc/assets/utils_style.css
@@ -1,11 +1,17 @@
 .progress-bar{
-    max-width: 800px;
+    /*max-width: 800px;*/
     width: 100%;
-    height: 2rem;
+    height: 1.5rem;
     border: 1px solid #274247;
     border-radius: 10px;
+    position: relative;
 }
 
+#progress-bar-label{
+    position: absolute;
+    top: 150px;
+    z-index: 1;
+}
 progress::-webkit-progress-bar {
     background-color: white;
  }

--- a/src/datadoc/assets/utils_style.css
+++ b/src/datadoc/assets/utils_style.css
@@ -1,0 +1,14 @@
+.progress-bar{
+    max-width: 800px;
+    width: 100%;
+    height: 2rem;
+    border: 1px solid #274247;
+    border-radius: 10px;
+}
+
+progress::-webkit-progress-bar {
+    background-color: white;
+ }
+ progress::-webkit-progress-value {
+    background-color: green;
+ }

--- a/src/datadoc/assets/utils_style.css
+++ b/src/datadoc/assets/utils_style.css
@@ -1,7 +1,7 @@
 .progress-bar{
     /*max-width: 800px;*/
     width: 100%;
-    height: 1.5rem;
+    height: 1.8rem;
     border: 1px solid #274247;
     border-radius: 10px;
     position: relative;
@@ -9,12 +9,15 @@
 
 #progress-bar-label{
     position: absolute;
-    top: 150px;
+    top: 145px;
+    left: 20%;
     z-index: 1;
+    color: white;
+
 }
 progress::-webkit-progress-bar {
     background-color: white;
  }
  progress::-webkit-progress-value {
-    background-color: green;
+    background-color: #00824D;
  }

--- a/src/datadoc/assets/utils_style.css
+++ b/src/datadoc/assets/utils_style.css
@@ -1,7 +1,7 @@
 .progress-bar{
     width: 100%;
     height: 1.8rem;
-    border: 1px solid #274247;
+    border: 4px solid #B6E8B8;
     border-radius: 10px;
     position: relative;
 }

--- a/src/datadoc/frontend/callbacks/register_callbacks.py
+++ b/src/datadoc/frontend/callbacks/register_callbacks.py
@@ -52,7 +52,6 @@ def register_callbacks(app: Dash) -> None:
 
     @app.callback(
         Output("progress-bar", "value"),
-        Output("progress-bar", "label"),
         Input({"type": DATASET_METADATA_INPUT, "id": ALL}, "value"),
         Input(
             {
@@ -66,10 +65,9 @@ def register_callbacks(app: Dash) -> None:
     def callback_update_progress(
         value: MetadataInputTypes,  # noqa: ARG001 argument required by Dash
         data: list[dict],  # noqa: ARG001 argument required by Dash
-    ) -> tuple[int, str]:
+    ) -> str:
         """Update the progress bar when new data is entered."""
-        completion = state.metadata.percent_complete
-        return completion, f"{completion}%"
+        return str(state.metadata.percent_complete)
 
     @app.callback(
         Output("saved-metadata-success", "is_open"),

--- a/src/datadoc/frontend/callbacks/register_callbacks.py
+++ b/src/datadoc/frontend/callbacks/register_callbacks.py
@@ -76,10 +76,10 @@ def register_callbacks(app: Dash) -> None:
         Input("progress-bar", "value"),
     )
     def callback_update_progress_label(
-        value: str,
+        value: MetadataInputTypes,  # noqa: ARG001 argument required by Dash
     ) -> str:
         """Update the progress bar label when progress bar is updated."""
-        return f"{value}%"
+        return f"{state.metadata.percent_complete}%"
 
     @app.callback(
         Output("saved-metadata-success", "is_open"),

--- a/src/datadoc/frontend/callbacks/register_callbacks.py
+++ b/src/datadoc/frontend/callbacks/register_callbacks.py
@@ -70,6 +70,16 @@ def register_callbacks(app: Dash) -> None:
         return str(state.metadata.percent_complete)
 
     @app.callback(
+        Output("progress-bar-label", "children"),
+        Input("progress-bar", "value"),
+    )
+    def callback_update_progress_label(
+        value: str,
+    ) -> str:
+        """Update the progress bar label when progress bar is updated."""
+        return f"{value}%"
+
+    @app.callback(
         Output("saved-metadata-success", "is_open"),
         Input("save-button", "n_clicks"),
         prevent_initial_call=True,

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -20,7 +20,21 @@ header = ssb.Header(
 )
 
 progress_bar = dbc.CardBody(
-    children=[dbc.Progress(id="progress-bar", color=COLORS["green_4"], value=40)],
+    children=[
+        html.Label(
+            title="Progress",
+            children=[ssb.Title("Progress", size=6)],
+        ),
+        html.Progress(
+            id="progress-bar",
+            max="100",
+            value="0",
+            style={
+                "width": "800px",
+                "height": "3rem",
+            },
+        ),
+    ],
     className="progress-bar-wrapper",
 )
 

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -19,12 +19,11 @@ header = ssb.Header(
     className="datadoc-header",
 )
 
-progress_bar = dbc.CardBody(
+progress_bar = html.Div(
     children=[
         html.Label(
             title="progress-bar",
             id="progress-bar-label",
-            children=[ssb.Title("Progress", size=6)],
         ),
         html.Progress(
             id="progress-bar",

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -23,6 +23,7 @@ progress_bar = html.Div(
     children=[
         html.Label(
             title="progress-bar",
+            htmlFor="progress-bar",
             id="progress-bar-label",
         ),
         html.Progress(

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -29,10 +29,7 @@ progress_bar = dbc.CardBody(
             id="progress-bar",
             max="100",
             value="0",
-            style={
-                "width": "800px",
-                "height": "3rem",
-            },
+            className="progress-bar",
         ),
     ],
     className="progress-bar-wrapper",

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -12,7 +12,7 @@ from datadoc.enums import SupportedLanguages
 from datadoc.frontend.callbacks.utils import get_dataset_path
 from datadoc.utils import get_app_version
 
-COLORS = {"dark_1": "#F0F8F9", "green_1": "#ECFEED", "green_4": "#00824D"}
+# COLORS = {"dark_1": "#F0F8F9", "green_1": "#ECFEED", "green_4": "#00824D"}
 
 header = ssb.Header(
     [ssb.Title("Datadoc", size=1, id="main-title", className="main-title")],

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -22,7 +22,8 @@ header = ssb.Header(
 progress_bar = dbc.CardBody(
     children=[
         html.Label(
-            title="Progress",
+            title="progress-bar",
+            id="progress-bar-label",
             children=[ssb.Title("Progress", size=6)],
         ),
         html.Progress(


### PR DESCRIPTION
The previous progressbar failed at accessibility test, but the problem is solved by using html element "progress" with a label. Values are string. The label text is updated in separate callback and label is positioned on top of the progressbar.

Colors and font-weight has been updated after failing color contrast

Tested in Chrome:
<img width="1218" alt="Screenshot 2024-04-18 at 17 22 28" src="https://github.com/statisticsnorway/datadoc/assets/68303562/efc36744-9b53-41ba-b758-9de334e7a1a4">


Tested in Firefox: 
<img width="1192" alt="Screenshot 2024-04-18 at 17 22 43" src="https://github.com/statisticsnorway/datadoc/assets/68303562/c4142c48-615f-4fbf-bbcd-c8f262b74cb8">


Tested in Safari:
<img width="1243" alt="Screenshot 2024-04-18 at 17 23 19" src="https://github.com/statisticsnorway/datadoc/assets/68303562/4efb7029-5fbf-4c11-9e4a-db471784702b">


Tested in Edge:
<img width="1248" alt="Screenshot 2024-04-18 at 17 22 59" src="https://github.com/statisticsnorway/datadoc/assets/68303562/1ab4f34c-6f50-443d-a9b4-062eb5ed2bc8">



