### PR TITLE
Only open a dataset on button press

### DIFF
--- a/src/datadoc/frontend/callbacks/register_callbacks.py
+++ b/src/datadoc/frontend/callbacks/register_callbacks.py
@@ -168,7 +168,7 @@ def register_callbacks(app: Dash) -> None:
         Output("opened-dataset-error-explanation", "children"),
         Output("dataset-opened-counter", "data"),  # Used to force reload of metadata
         Input("open-button", "n_clicks"),
-        Input("dataset-path-input", "value"),
+        State("dataset-path-input", "value"),
         State("dataset-opened-counter", "data"),
         prevent_initial_call=True,
     )


### PR DESCRIPTION
I experimented with allowing opening a dataset by hitting the enter key, but since this can potentially cause the loss of data, it's better to make it an explicit action.