### PR TITLE
Use original ssb colors on progressbar

### DIFF
--- a/src/datadoc/assets/progressbar_style.css
+++ b/src/datadoc/assets/progressbar_style.css
@@ -6,22 +6,27 @@
     background-color: #C3DCDC;
 }
 
+.progress-bar[value]{
+    background-color: #00824D;
+}
+
 #progress-bar-label{
     position: absolute;
     top: 145px;
     left: 25%;
     z-index: 1;
-    color: #162327;
+    color: white;
     font-weight: 502;
-
 }
+
 progress::-webkit-progress-bar {
     background-color: #C3DCDC;
- }
- progress::-webkit-progress-value {
-    background-color: #1A9D49;
- }
+}
 
- progress[value]::-moz-progress-bar{
-    background-color: #1A9D49;
- }
+progress::-webkit-progress-value {
+    background-color: #00824D;
+}
+
+progress[value]::-moz-progress-bar{
+    background-color: #00824D;
+}


### PR DESCRIPTION
SSB colour combination dark green and white failed colour contrast checker because of missing progress value set on class 'progress-bar. The value was only set on the element 'progress'. This was not visible on screen.