### PR TITLE
Inherit dataset value - multilanguage

### DIFF
--- a/src/datadoc/frontend/callbacks/dataset.py
+++ b/src/datadoc/frontend/callbacks/dataset.py
@@ -176,6 +176,7 @@ def accept_dataset_metadata_input(
             value,
         )
         set_variables_values_inherited_from_dataset(value, metadata_identifier)
+        logger.info("Dont change dataset value: %s", value)
     except (ValidationError, ValueError):
         show_error = True
         error_explanation = INVALID_VALUE

--- a/src/datadoc/frontend/callbacks/dataset.py
+++ b/src/datadoc/frontend/callbacks/dataset.py
@@ -16,6 +16,7 @@ from datadoc.frontend.callbacks.utils import MetadataInputTypes
 from datadoc.frontend.callbacks.utils import find_existing_language_string
 from datadoc.frontend.callbacks.utils import get_dataset_path
 from datadoc.frontend.callbacks.utils import parse_and_validate_dates
+from datadoc.frontend.callbacks.variables import set_variables_value_multilanguage
 from datadoc.frontend.callbacks.variables import (
     set_variables_values_inherited_from_dataset,
 )
@@ -117,6 +118,7 @@ def process_keyword(value: str) -> list[str]:
     return [item.strip() for item in value.split(",")]
 
 
+# legge inn population update her?
 def process_special_cases(
     value: MetadataInputTypes | LanguageStringType,
     metadata_identifier: str,
@@ -147,6 +149,7 @@ def process_special_cases(
                 metadata_identifier,
                 language,
             )
+            set_variables_value_multilanguage(value, metadata_identifier, language)
     elif metadata_identifier in DROPDOWN_DATASET_METADATA_IDENTIFIERS and value == "":
         updated_value = None
     else:
@@ -176,7 +179,6 @@ def accept_dataset_metadata_input(
             value,
         )
         set_variables_values_inherited_from_dataset(value, metadata_identifier)
-        logger.info("Dont change dataset value: %s", value)
     except (ValidationError, ValueError):
         show_error = True
         error_explanation = INVALID_VALUE

--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -244,6 +244,8 @@ def get_corresponding_identifier(
             return VariableIdentifiers.TEMPORALITY_TYPE
         case DatasetIdentifiers.DATA_SOURCE:
             return VariableIdentifiers.DATA_SOURCE
+        case DatasetIdentifiers.POPULATION_DESCRIPTION:
+            return VariableIdentifiers.POPULATION_DESCRIPTION
         case _:
             return None
 

--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -244,10 +244,41 @@ def get_corresponding_identifier(
             return VariableIdentifiers.TEMPORALITY_TYPE
         case DatasetIdentifiers.DATA_SOURCE:
             return VariableIdentifiers.DATA_SOURCE
+        case _:
+            return None
+
+
+def get_corresponding_multilanguage_identifier(
+    metadata_identifier: str,
+) -> str | None:
+    """Get the corresponding variables multilanguage identifier for dataset identifier."""
+    match metadata_identifier:
         case DatasetIdentifiers.POPULATION_DESCRIPTION:
             return VariableIdentifiers.POPULATION_DESCRIPTION
         case _:
             return None
+
+
+def set_variables_value_multilanguage(
+    value: MetadataInputTypes | LanguageStringType,
+    metadata_identifier: str,
+    language: str,
+) -> None:
+    """Set variable multilanguage value based on dataset value."""
+    variable = get_corresponding_multilanguage_identifier(metadata_identifier)
+    if value is not None and variable is not None:
+        for val in state.metadata.variables:
+            update_value = handle_multi_language_metadata(
+                variable,
+                value,
+                val.short_name,
+                language,
+            )
+            setattr(
+                state.metadata.variables_lookup[val.short_name],
+                variable,
+                update_value,
+            )
 
 
 def set_variables_values_inherited_from_dataset(

--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -247,15 +247,14 @@ def variable_identifier(
     return metadata_identifiers.get(dataset_identifier)
 
 
-def get_corresponding_multilanguage_identifier(
-    metadata_identifier: str,
+def variable_identifier_multilanguage(
+    dataset_identifier: str,
 ) -> str | None:
-    """Get the corresponding variables multilanguage identifier for dataset identifier."""
-    match metadata_identifier:
-        case DatasetIdentifiers.POPULATION_DESCRIPTION:
-            return VariableIdentifiers.POPULATION_DESCRIPTION
-        case _:
-            return None
+    """Pair corresponding identifiers for multilanguage fields."""
+    metadata_identifiers = {
+        "population_description": VariableIdentifiers.POPULATION_DESCRIPTION,
+    }
+    return metadata_identifiers.get(dataset_identifier)
 
 
 def set_variables_value_multilanguage(
@@ -264,7 +263,7 @@ def set_variables_value_multilanguage(
     language: str,
 ) -> None:
     """Set variable multilanguage value based on dataset value."""
-    variable = get_corresponding_multilanguage_identifier(metadata_identifier)
+    variable = variable_identifier_multilanguage(metadata_identifier)
     if value is not None and variable is not None:
         for val in state.metadata.variables:
             update_value = handle_multi_language_metadata(

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -21,6 +21,7 @@ from datadoc.frontend.callbacks.variables import (
     set_variables_values_inherited_from_dataset,
 )
 from datadoc.frontend.fields.display_base import get_metadata_and_stringify
+from datadoc.frontend.fields.display_base import get_standard_metadata
 from datadoc.frontend.fields.display_dataset import DatasetIdentifiers
 from datadoc.frontend.fields.display_variables import DISPLAY_VARIABLES
 from datadoc.frontend.fields.display_variables import VariableIdentifiers

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -13,7 +13,6 @@ from pydantic_core import Url
 
 from datadoc import enums
 from datadoc import state
-from datadoc.frontend.callbacks.utils import find_existing_language_string
 from datadoc.frontend.callbacks.variables import accept_variable_metadata_date_input
 from datadoc.frontend.callbacks.variables import accept_variable_metadata_input
 from datadoc.frontend.callbacks.variables import populate_variables_workspace
@@ -388,25 +387,23 @@ def test_variables_value_can_be_changed_after_update_from_dataset_value(
     )
 
 
-# TODO(<tilen1976>): add test for multilanguage  updated value # noqa: TD003
-# TODO(<tilen1976>):Remove after decision how to save inherit value: root=[LanguageStringTypeItem(languageCode='nn', languageText='cvhbj'), LanguageStringTypeItem(languageCode='nb', languageText='Personer')]  # noqa: TD007, TD003
 def test_update_variables_multilanguage_values_from_dataset_values(
     metadata: DataDocMetadata,
 ):
     state.metadata = metadata
     dataset_population_description = "Personer bosatt i Norge"
+    dataset_population_description_language_item = [
+        LanguageStringTypeItem(
+            languageCode="nb",
+            languageText="Personer bosatt i Norge",
+        ),
+    ]
     metadata_identifier = DatasetIdentifiers.POPULATION_DESCRIPTION
     language = "nb"
-    updated_value = find_existing_language_string(
-        state.metadata.dataset,
-        dataset_population_description,
-        metadata_identifier,
-        language,
-    )
     setattr(
         state.metadata.dataset,
         metadata_identifier,
-        updated_value,
+        dataset_population_description_language_item,
     )
     set_variables_value_multilanguage(
         dataset_population_description,
@@ -425,7 +422,7 @@ def test_variables_multilanguage_value_can_be_changed_after_update_from_dataset_
 ):
     state.metadata = metadata
     dataset_population_description = "Persons in Norway"
-    dataset_language_item = [
+    dataset_population_description_language_item = [
         LanguageStringTypeItem(languageCode="en", languageText="Persons in Norway"),
     ]
     dataset_identifier = DatasetIdentifiers.POPULATION_DESCRIPTION
@@ -434,7 +431,7 @@ def test_variables_multilanguage_value_can_be_changed_after_update_from_dataset_
     setattr(
         state.metadata.dataset,
         dataset_identifier,
-        dataset_language_item,
+        dataset_population_description_language_item,
     )
     set_variables_value_multilanguage(
         dataset_population_description,

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -399,7 +399,7 @@ def test_variables_values_inherit_dataset_values(
         ),
     ],
 )
-def test_variables_values_can_be_changed_after_update_from_dataset_value(
+def test_variables_values_can_be_changed_after_inherit_dataset_value(
     dataset_value,
     dataset_identifier,
     variable_identifier,
@@ -443,7 +443,7 @@ def test_variables_values_can_be_changed_after_update_from_dataset_value(
     )
 
 
-def test_update_variables_multilanguage_values_from_dataset_values(
+def test_variables_values_multilanguage_inherit_dataset_values(
     metadata: DataDocMetadata,
 ):
     state.metadata = metadata
@@ -473,7 +473,7 @@ def test_update_variables_multilanguage_values_from_dataset_values(
         )
 
 
-def test_variables_multilanguage_value_can_be_changed_after_update_from_dataset_value(
+def test_variables_values_multilanguage_can_be_changed_after_inherit_dataset_value(
     metadata: DataDocMetadata,
 ):
     state.metadata = metadata

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -383,3 +383,6 @@ def test_variables_value_can_be_changed_after_update_from_dataset_value(
         )
         == "ACCUMULATED"
     )
+
+
+# TODO(<tilen1976>): add test for multilanguage  # noqa: TD003


### PR DESCRIPTION
- Separate method for inherit multi language values to avoid all values are changed when one value is changed
- Called where multi language values are processed 
- Separate dict for multi language identifiers in case more multi language can be inherited, if not this logic can be moved to method set_variables_value_multilanguage()
