### PR TITLE
Bump mabl action to one that supports node v20

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Run mabl tests
         id: mabl-test-deployment
-        uses: mablhq/github-run-tests-action@v1
+        uses: mablhq/github-run-tests-action@v1.14
         env:
           # Use a "CI/CD Integration" type of mabl API key
           MABL_API_KEY: ${{ secrets.MABL_API_KEY }}


### PR DESCRIPTION
This resolves the warning when running the action.

Fixed by the Mabl team under https://github.com/mablhq/github-run-tests-action/issues/60 🙌 