### PR TITLE
Change definition uri to recommended

### DIFF
--- a/src/datadoc/frontend/fields/display_variables.py
+++ b/src/datadoc/frontend/fields/display_variables.py
@@ -98,7 +98,7 @@ DISPLAY_VARIABLES: dict[
         identifier=VariableIdentifiers.DEFINITION_URI.value,
         display_name="Definition URI",
         description="Oppgi lenke (URI) til tilhørende variabel i VarDef.",
-        obligatory=True,
+        obligatory=False,
     ),
     VariableIdentifiers.DIRECT_PERSON_IDENTIFYING: MetadataCheckboxField(
         identifier=VariableIdentifiers.DIRECT_PERSON_IDENTIFYING.value,

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -83,7 +83,7 @@ def test_metadata_document_percent_complete(metadata: DataDocMetadata):
     metadata.dataset = document.dataset  # type: ignore [assignment]
     metadata.variables = document.variables  # type: ignore [assignment]
 
-    assert metadata.percent_complete == 11  # noqa: PLR2004
+    assert metadata.percent_complete == 12  # noqa: PLR2004
 
 
 def test_write_metadata_document(


### PR DESCRIPTION
- Set Definition uri field as recommended by changing obligatory from True to False
- Update test measuring document percent complete because definition uri is no longer included