### PR TITLE
Open dataset path and metadata path

### DIFF
--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -63,15 +63,15 @@ class Datadoc:
         self.variables_lookup: dict[str, model.Variable] = {}
         if metadata_document_path:
             # In this case the user has specified an independent metadata document for editing
-            # without a dataset.
             self.metadata_document = normalize_path(metadata_document_path)
-        elif dataset_path:
+        if dataset_path:
             self.dataset_path = normalize_path(dataset_path)
-            # Build the metadata document path based on the dataset path
+            # Build the metadata document path based on the dataset path if no metadata document is supplied
             # Example: /path/to/dataset.parquet -> /path/to/dataset__DOC.json
-            self.metadata_document = self.dataset_path.parent / (
-                self.dataset_path.stem + METADATA_DOCUMENT_FILE_SUFFIX
-            )
+            if not metadata_document_path:
+                self.metadata_document = self.dataset_path.parent / (
+                    self.dataset_path.stem + METADATA_DOCUMENT_FILE_SUFFIX
+                )
         self._extract_metadata_from_files()
 
     def _extract_metadata_from_files(self) -> None:
@@ -105,7 +105,11 @@ class Datadoc:
         self,
         document: pathlib.Path | CloudPath,
     ) -> None:
-        """There's an existing metadata document, so read in the metadata from that."""
+        """There's an existing metadata document, so read in the metadata from that.
+
+        Args:
+            document: A path to the existing metadata document
+        """
         fresh_metadata = {}
         try:
             with document.open(mode="r", encoding="utf-8") as file:

--- a/tests/backend/test_datadoc_metadata.py
+++ b/tests/backend/test_datadoc_metadata.py
@@ -425,3 +425,11 @@ def test_default_spatial_coverage_description(
 ):
     ls = metadata.dataset.spatial_coverage_description
     assert ls.root[index].languageText == expected_text  # type: ignore[union-attr, index]
+
+
+def test_datadoc_dataset_and_metadata(datadoc_dataset_and_metadata: Datadoc):
+    assert (
+        str(datadoc_dataset_and_metadata.metadata_document)
+        == "tests/resources/existing_metadata_file/person_data_v1__DOC.json"
+    )
+    assert str(datadoc_dataset_and_metadata.dataset_path) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from tests.backend.test_statistic_subject_mapping import (
 
 from .utils import TEST_EXISTING_METADATA_DIRECTORY
 from .utils import TEST_EXISTING_METADATA_FILE_NAME
+from .utils import TEST_EXISTING_METADATA_FILEPATH
 from .utils import TEST_PARQUET_FILE_NAME
 from .utils import TEST_PARQUET_FILEPATH
 from .utils import TEST_RESOURCES_DIRECTORY
@@ -82,6 +83,21 @@ def metadata(
     shutil.copy(TEST_PARQUET_FILEPATH, tmp_path / TEST_PARQUET_FILE_NAME)
     return Datadoc(
         str(tmp_path / TEST_PARQUET_FILE_NAME),
+        statistic_subject_mapping=subject_mapping_fake_statistical_structure,
+    )
+
+
+@pytest.fixture()
+def datadoc_dataset_and_metadata(
+    _mock_timestamp: None,
+    _mock_user_info: None,
+    subject_mapping_fake_statistical_structure: StatisticSubjectMapping,
+    tmp_path: Path,
+) -> Datadoc:
+    shutil.copy(TEST_PARQUET_FILEPATH, tmp_path / TEST_PARQUET_FILE_NAME)
+    return Datadoc(
+        str(tmp_path / TEST_PARQUET_FILE_NAME),
+        str(TEST_EXISTING_METADATA_FILEPATH),
         statistic_subject_mapping=subject_mapping_fake_statistical_structure,
     )
 


### PR DESCRIPTION
- Changed core to allow for a data set path, as well as a metadata document path
- Added test checking that both paths exists