### PR TITLE
Implement pre-merge checks based on dataset path

### DIFF
--- a/src/datadoc/backend/constants.py
+++ b/src/datadoc/backend/constants.py
@@ -9,6 +9,10 @@ DATE_VALIDATION_MESSAGE = f"{VALIDATION_ERROR}contains_data_from must be the sam
 
 OBLIGATORY_METADATA_WARNING = "Obligatory metadata is missing: "
 
+INCONSISTENCIES_MESSAGE = (
+    "Inconsistencies found between extracted and existing metadata."
+)
+
 OBLIGATORY_DATASET_METADATA_IDENTIFIERS: list = [
     "assessment",
     "dataset_state",

--- a/src/datadoc/backend/constants.py
+++ b/src/datadoc/backend/constants.py
@@ -9,9 +9,7 @@ DATE_VALIDATION_MESSAGE = f"{VALIDATION_ERROR}contains_data_from must be the sam
 
 OBLIGATORY_METADATA_WARNING = "Obligatory metadata is missing: "
 
-INCONSISTENCIES_MESSAGE = (
-    "Inconsistencies found between extracted and existing metadata."
-)
+INCONSISTENCIES_MESSAGE = "Inconsistencies found between extracted and existing metadata. Inconsistencies are:"
 
 OBLIGATORY_DATASET_METADATA_IDENTIFIERS: list = [
     "assessment",

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -144,6 +144,7 @@ class Datadoc:
             self._check_ready_to_merge(
                 self.dataset_path,
                 Path(extracted_metadata.dataset.file_path),
+                errors_as_warnings=self.errors_as_warnings,
             )
             merged_metadata = self._merge_metadata(
                 extracted_metadata,
@@ -188,6 +189,13 @@ class Datadoc:
         new_dataset_path_info = DaplaDatasetPathInfo(new_dataset_path)
         existing_dataset_path_info = DaplaDatasetPathInfo(existing_dataset_path)
         results = [
+            {
+                "name": "Bucket name",
+                "success": (
+                    new_dataset_path_info.bucket_name
+                    == existing_dataset_path_info.bucket_name
+                ),
+            },
             {
                 "name": "Data product name",
                 "success": (

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -141,9 +141,18 @@ class Datadoc:
             extracted_metadata = self._extract_metadata_from_dataset(self.dataset_path)
 
         if self.dataset_path and self.explicitly_defined_metadata_document:
+            if (
+                extracted_metadata is not None
+                and extracted_metadata.dataset is not None
+                and extracted_metadata.dataset.file_path is not None
+            ):
+                existing_file_path = extracted_metadata.dataset.file_path
+            else:
+                msg = "Could not access existing dataset file path"
+                raise ValueError(msg)
             self._check_ready_to_merge(
                 self.dataset_path,
-                Path(extracted_metadata.dataset.file_path),
+                Path(existing_file_path),
                 errors_as_warnings=self.errors_as_warnings,
             )
             merged_metadata = self._merge_metadata(
@@ -221,7 +230,7 @@ class Datadoc:
         if failures := [result for result in results if not result["success"]]:
             if errors_as_warnings:
                 warnings.warn(
-                    message=f"{INCONSISTENCIES_MESSAGE} inconsistencies are: {', '.join(r['name'] for r in failures)}",
+                    message=f"{INCONSISTENCIES_MESSAGE} inconsistencies are: {', '.join(str(f['name']) for f in failures)}",
                     category=InconsistentDatasetsWarning,
                     stacklevel=2,
                 )

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -187,8 +187,7 @@ class Datadoc:
     ) -> None:
         new_dataset_path_info = DaplaDatasetPathInfo(new_dataset_path)
         existing_dataset_path_info = DaplaDatasetPathInfo(existing_dataset_path)
-        results = []
-        results.append(
+        results = [
             {
                 "name": "Data product name",
                 "success": (
@@ -196,7 +195,21 @@ class Datadoc:
                     == existing_dataset_path_info.statistic_short_name
                 ),
             },
-        )
+            {
+                "name": "Dataset state",
+                "success": (
+                    new_dataset_path_info.dataset_state
+                    == existing_dataset_path_info.dataset_state
+                ),
+            },
+            {
+                "name": "Dataset short name",
+                "success": (
+                    new_dataset_path_info.dataset_short_name
+                    == existing_dataset_path_info.dataset_short_name
+                ),
+            },
+        ]
         if failures := [result for result in results if not result["success"]]:
             if errors_as_warnings:
                 warnings.warn(

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -88,7 +88,7 @@ class Datadoc:
             dataset_path (Optional): The file path to the dataset.
             metadata_document_path (Optional): The file path to the metadata document.
             statistic_subject_mapping (Optional): An instance of StatisticSubjectMapping.
-            errors_as_warnings (Optional): Disable raising exceptions if inconsistencies are found between existing and extracted metadata.
+            errors_as_warnings: Disable raising exceptions if inconsistencies are found between existing and extracted metadata.
         """
         self._statistic_subject_mapping = statistic_subject_mapping
         self.errors_as_warnings = errors_as_warnings

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -198,9 +198,9 @@ class Datadoc:
         """Check if the datasets are consistent enough to make a successful merge of metadata.
 
         Args:
-            new_dataset_path (Path | CloudPath): Path to the dataset to be documented.
-            existing_dataset_path (Path): Path stored in the existing metadata.
-            errors_as_warnings (bool): True if failing checks should be raised as warnings, not errors.
+            new_dataset_path: Path to the dataset to be documented.
+            existing_dataset_path: Path stored in the existing metadata.
+            errors_as_warnings: True if failing checks should be raised as warnings, not errors.
 
         Raises:
             InconsistentDatasetsError: If inconsistencies are found and `errors_as_warnings == False`

--- a/src/datadoc/backend/core.py
+++ b/src/datadoc/backend/core.py
@@ -195,6 +195,16 @@ class Datadoc:
         *,
         errors_as_warnings: bool,
     ) -> None:
+        """Check if the datasets are consistent enough to make a successful merge of metadata.
+
+        Args:
+            new_dataset_path (Path | CloudPath): Path to the dataset to be documented.
+            existing_dataset_path (Path): Path stored in the existing metadata.
+            errors_as_warnings (bool): True if failing checks should be raised as warnings, not errors.
+
+        Raises:
+            InconsistentDatasetsError: If inconsistencies are found and `errors_as_warnings == False`
+        """
         new_dataset_path_info = DaplaDatasetPathInfo(new_dataset_path)
         existing_dataset_path_info = DaplaDatasetPathInfo(existing_dataset_path)
         results = [
@@ -228,14 +238,17 @@ class Datadoc:
             },
         ]
         if failures := [result for result in results if not result["success"]]:
+            msg = f"{INCONSISTENCIES_MESSAGE} {', '.join(str(f['name']) for f in failures)}"
             if errors_as_warnings:
                 warnings.warn(
-                    message=f"{INCONSISTENCIES_MESSAGE} inconsistencies are: {', '.join(str(f['name']) for f in failures)}",
+                    message=msg,
                     category=InconsistentDatasetsWarning,
                     stacklevel=2,
                 )
             else:
-                raise InconsistentDatasetsError(INCONSISTENCIES_MESSAGE)
+                raise InconsistentDatasetsError(
+                    msg,
+                )
 
     @staticmethod
     def _merge_metadata(

--- a/src/datadoc/backend/dapla_dataset_path_info.py
+++ b/src/datadoc/backend/dapla_dataset_path_info.py
@@ -13,6 +13,7 @@ from typing import Final
 from typing import Literal
 
 import arrow
+from cloudpathlib import GSPath
 
 from datadoc.enums import DataSetState
 from datadoc.enums import SupportedLanguages
@@ -23,6 +24,8 @@ if TYPE_CHECKING:
     from datetime import date
 
 logger = logging.getLogger(__name__)
+
+GS_PREFIX_FROM_PATHLIB = "gs:/"
 
 
 @dataclass
@@ -323,6 +326,7 @@ class DaplaDatasetPathInfo:
 
     def __init__(self, dataset_path: str | os.PathLike[str]) -> None:
         """Digest the path so that it's ready for further parsing."""
+        self.dataset_string = str(dataset_path)
         self.dataset_path = pathlib.Path(dataset_path)
         self.dataset_name_sections = self.dataset_path.stem.split("_")
         self._period_strings = self._extract_period_strings(self.dataset_name_sections)
@@ -446,6 +450,40 @@ class DaplaDatasetPathInfo:
                 norwegian_dataset_state_path_part.replace(" ", x) for x in ["-", "_"]
             }
         return return_value
+
+    @property
+    def bucket_name(
+        self,
+    ) -> str | None:
+        """Extract the bucket name from the dataset path.
+
+        Returns:
+            str | None: The bucket name or None if the dataset path is not a GCS path.
+
+        Examples:
+            >>> DaplaDatasetPathInfo('gs://ssb-staging-dapla-felles-data-delt/datadoc/utdata/person_data_p2021_v2.parquet').bucket_name
+            ssb-staging-dapla-felles-data-delt
+
+            >>> DaplaDatasetPathInfo(pathlib.Path('gs://ssb-staging-dapla-felles-data-delt/datadoc/utdata/person_data_p2021_v2.parquet')).bucket_name
+            ssb-staging-dapla-felles-data-delt
+
+            >>> DaplaDatasetPathInfo('gs:/ssb-staging-dapla-felles-data-delt/datadoc/utdata/person_data_p2021_v2.parquet').bucket_name
+            ssb-staging-dapla-felles-data-delt
+
+            >>> DaplaDatasetPathInfo('ssb-staging-dapla-felles-data-delt/datadoc/utdata/person_data_p2021_v2.parquet').bucket_name
+            None
+        """
+        prefix: str | None = None
+        if self.dataset_string.startswith(GSPath.cloud_prefix):
+            prefix = GSPath.cloud_prefix
+        elif self.dataset_string.startswith(GS_PREFIX_FROM_PATHLIB):
+            prefix = GS_PREFIX_FROM_PATHLIB
+        else:
+            return None
+
+        return pathlib.Path(
+            self.dataset_string.removeprefix(prefix),
+        ).parts[0]
 
     @property
     def dataset_short_name(

--- a/src/datadoc/backend/dapla_dataset_path_info.py
+++ b/src/datadoc/backend/dapla_dataset_path_info.py
@@ -458,7 +458,7 @@ class DaplaDatasetPathInfo:
         """Extract the bucket name from the dataset path.
 
         Returns:
-            str | None: The bucket name or None if the dataset path is not a GCS path.
+            The bucket name or None if the dataset path is not a GCS path.
 
         Examples:
             >>> DaplaDatasetPathInfo('gs://ssb-staging-dapla-felles-data-delt/datadoc/utdata/person_data_p2021_v2.parquet').bucket_name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,8 @@ TEST_BUCKET_PARQUET_FILEPATH = "gs://ssb-staging-dapla-felles-data-delt/datadoc/
 
 TEST_BUCKET_PARQUET_FILEPATH_WITH_SHORTNAME = "gs://ssb-staging-dapla-felles-data-delt/befolkning/klargjorte_data/person_data_v1.parquet"
 
+TEST_BUCKET_NAMING_STANDARD_COMPATIBLE_PATH = "gs://ssb-my-team-data-produkt-prod/ifpn/klargjorte_data/person_testdata_p2021-12-31_p2021-12-31_v1.parquet"
+
 TEST_RESOURCES_DIRECTORY = Path("tests/resources")
 TEST_DATASETS_DIRECTORY = TEST_RESOURCES_DIRECTORY / "datasets"
 


### PR DESCRIPTION
Checks for consistency in:
- Bucket name
- Data product name
- Dataset state
- Dataset short name

If `errors_as_warnings == True` a warning is raised, otherwise an exception is raised.

Checks based on variables will be implemented in a future PR.
