### PR TITLE
Fix save-button position

### DIFF
--- a/src/datadoc/assets/controlbar_style.css
+++ b/src/datadoc/assets/controlbar_style.css
@@ -1,6 +1,5 @@
 .control-bar-section{
     display: flex;
-    flex-wrap: wrap;
     gap: 0.5rem;
     padding: 1rem 0;
     align-items: center;
@@ -9,7 +8,6 @@
 
 .ssb-input.file-path-input{
     max-width: 1100px;
-    width: 100%;
 }
 
 .ssb-btn.secondary-btn.file-open-button,.ssb-btn.secondary-btn.file-save-button{
@@ -111,4 +109,10 @@
 .button-section{
   display: flex;
   gap: 0.5rem;
+}
+
+@media only screen and (max-width: 1200px) {
+  .control-bar-section{
+    flex-wrap: wrap;
+  }
 }

--- a/src/datadoc/assets/controlbar_style.css
+++ b/src/datadoc/assets/controlbar_style.css
@@ -1,7 +1,7 @@
 .control-bar-section{
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.5rem;
     padding: 1rem 0;
     align-items: center;
     margin-top: 1rem;
@@ -106,4 +106,9 @@
 #alerts-section > div.fade.ssb-alert.alert.alert-warning.alert-dismissible.show > .alert_list{
   margin: 0;
   margin-top: 1rem;
+}
+
+.button-section{
+  display: flex;
+  gap: 0.5rem;
 }

--- a/src/datadoc/assets/controlbar_style.css
+++ b/src/datadoc/assets/controlbar_style.css
@@ -2,7 +2,7 @@
     display: flex;
     gap: 0.5rem;
     padding: 1rem 0;
-    align-items: center;
+    align-items: end;
     margin-top: 1rem;
 }
 

--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -49,15 +49,20 @@ def build_controls_bar() -> html.Section:
                 className="file-path-input",
                 id="dataset-path-input",
             ),
-            ssb.Button(
-                children=["Åpne fil"],
-                id="open-button",
-                className="file-open-button",
-            ),
-            ssb.Button(
-                children=["Lagre metadata"],
-                id="save-button",
-                className="file-save-button",
+            html.Section(
+                [
+                    ssb.Button(
+                        children=["Åpne fil"],
+                        id="open-button",
+                        className="file-open-button",
+                    ),
+                    ssb.Button(
+                        children=["Lagre metadata"],
+                        id="save-button",
+                        className="file-save-button",
+                    ),
+                ],
+                className="button-section",
             ),
         ],
         className="control-bar-section",


### PR DESCRIPTION
- Make sure save-button is aligned with other items in control-bar
- Add breakpoint at 1200px 
- Group open- and save-button so that they align together under input for filepath when screen is smaller than breakpoint
- Align all items in controlbar at the bottom (end)

