### PR TITLE
Make variable id visible

### DIFF
--- a/src/datadoc/frontend/callbacks/variables.py
+++ b/src/datadoc/frontend/callbacks/variables.py
@@ -22,6 +22,7 @@ from datadoc.frontend.fields.display_variables import DISPLAY_VARIABLES
 from datadoc.frontend.fields.display_variables import (
     MULTIPLE_LANGUAGE_VARIABLES_METADATA,
 )
+from datadoc.frontend.fields.display_variables import NON_EDITABLE_VARIABLES_METADATA
 from datadoc.frontend.fields.display_variables import OBLIGATORY_VARIABLES_METADATA
 from datadoc.frontend.fields.display_variables import (
     OBLIGATORY_VARIABLES_METADATA_IDENTIFIERS_AND_DISPLAY_NAME,
@@ -66,6 +67,11 @@ def populate_variables_workspace(
                 build_edit_section(
                     OPTIONAL_VARIABLES_METADATA,
                     "Anbefalt",
+                    variable,
+                ),
+                build_edit_section(
+                    NON_EDITABLE_VARIABLES_METADATA,
+                    "Maskingenerert",
                     variable,
                 ),
             ],

--- a/src/datadoc/frontend/fields/display_variables.py
+++ b/src/datadoc/frontend/fields/display_variables.py
@@ -212,3 +212,7 @@ OBLIGATORY_VARIABLES_METADATA_IDENTIFIERS_AND_DISPLAY_NAME: list[tuple] = [
     for m in DISPLAY_VARIABLES.values()
     if m.obligatory and m.editable
 ]
+
+NON_EDITABLE_VARIABLES_METADATA = [
+    m for m in DISPLAY_VARIABLES.values() if not m.editable
+]


### PR DESCRIPTION
## Summary

This is a suggestion where all non-editable variable fields are visible in a separate section. 

- **add non-editable list for variables**
- **add non-editable section**

## Screenshot
![Screenshot 2024-08-19 at 11 37 40](https://github.com/user-attachments/assets/7687034e-78a4-487b-8a32-39d8fdb27067)

