### PR TITLE
Add prop for opening documentation link in new tab

### DIFF
--- a/src/datadoc/frontend/components/control_bars.py
+++ b/src/datadoc/frontend/components/control_bars.py
@@ -14,6 +14,7 @@ header = ssb.Header(
         ssb.Link(
             "Dokumentasjon",
             href="https://manual.dapla.ssb.no/statistikkere/datadoc.html",
+            isExternal=True,
         ),
     ],
     className="datadoc-header",


### PR DESCRIPTION
activate prop in Link component to open Documentation in new tab - important when reading documentation while documenting dataset