### PR TITLE
add include-hidden-files: true

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           name: coverage-data-${{ matrix.os }}-${{ matrix.python }}
           path: ".coverage.*"
+          include-hidden-files: true
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'


### PR DESCRIPTION
Issue in github actions with uploading coverage was caused by breaking changes in https://github.com/actions/upload-artifact/issues/602
Hidden files must now be included explicitly.