### PR TITLE
Bump version 1.0.1 -> 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-datadoc"
-version = "1.0.1"
+version = "1.0.2"
 description = "Document dataset metadata. For use in Statistics Norway's metadata system."
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Added fix to not being able to edit metadata on short names that have non ascii characters