### PR TITLE
Switch Mabl workspace

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: test
           RESOURCE: .nais/test-pr.yaml
           VAR: image=${{ needs.docker-build.outputs.image-tag }},pr-number=${{github.event.number}}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -104,6 +104,6 @@ jobs:
         with:
           application-id: ${{ secrets.DATADOC_MABL_APPLICATION_ID }}
           environment-id: ${{ secrets.DATADOC_MABL_ENVIRONMENT_ID }}
-          uri: https://datadoc-pr-${{github.event.number}}.external.test.ssb.cloud.nais.io
+          uri: https://datadoc-pr-${{github.event.number}}.test.ssb.no
           mabl-branch: ${{ github.head_ref }}
           plan-labels: Datadoc

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,6 +77,9 @@ jobs:
     name: Deploy to NAIS
     runs-on: ubuntu-latest
     needs: docker-build
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v4
       - uses: nais/deploy/actions/deploy@v2

--- a/.nais/test-pr.yaml
+++ b/.nais/test-pr.yaml
@@ -34,7 +34,7 @@ spec:
     enabled: false
 
   ingresses:
-    - https://datadoc-pr-{{ pr-number }}.external.test.ssb.cloud.nais.io
+    - https://datadoc-pr-{{ pr-number }}.test.ssb.no
 
   filesFrom:
     - configmap: integration-test-dataset


### PR DESCRIPTION
We are moving away from the shared SSB Workspace to one which is just for Dapla. The primary change involves updating repository secrets `MABL_API_KEY`, `DATADOC_MABL_APPLICATION_ID` and `DATADOC_MABL_ENVIRONMENT_ID`, this PR is necessary to test that those changes work though.

Example run: https://app.mabl.com/workspaces/JIcc6pQWNmEdg1yGti2yTw-w/train/tests/N5SzsnPlHsgG2xgUX7EIsA-j/test-runs/SuCuw8BsRnR9LcdUkEbqlg-jr

Ref: DPMETA-589
