### PR TITLE
Fix variables warnings not showing fields missing

### DIFF
--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -580,19 +580,19 @@ def test_variables_values_inherit_dataset_date_values_not_when_variable_has_valu
 def test_variables_metadata_control_return_alert(metadata: Datadoc):
     """Return alert when obligatory metadata is missing."""
     state.metadata = metadata
-    missing_metadata: str
+    missing_metadata: list = []
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         state.metadata.write_metadata_document()
         if issubclass(w[1].category, ObligatoryVariableWarning):
-            missing_metadata = str(w[1].message)
+            missing_metadata.append(str(w[1].message))
     result = variables_control(missing_metadata, metadata.variables)
     assert isinstance(result, dbc.Alert)
 
 
 def test_variables_metadata_control_dont_return_alert(metadata: Datadoc):
     state.metadata = metadata
-    missing_metadata: str | None = None
+    missing_metadata: list[str] = []
     for val in state.metadata.variables:
         """Not return alert when all obligatory metadata has value."""
         setattr(
@@ -626,7 +626,7 @@ def test_variables_metadata_control_dont_return_alert(metadata: Datadoc):
         warnings.simplefilter("always")
         state.metadata.write_metadata_document()
         if issubclass(w[0].category, ObligatoryVariableWarning):
-            missing_metadata = str(w[0].message)
+            missing_metadata.append(str(w[0].message))
     result = variables_control(missing_metadata, metadata.variables)
     assert result is None
 


### PR DESCRIPTION
Variables warnings in alert section was not showing which obligatory fields who was missing anymore.
The reason is that there are two validations, the second running only a millisecond after the first.
The first one holds the lists with missing fields per variable, the second has empty lists.
It could come from `write_metadata_document()` somewhere.

Solution:
Append all results to a list and use the first element. This could be fragile if validation in `Datadoc` or state/callbacks changes, but it should be good enough now. 
Added a `NOTE` comment in the code so if something breaks in the future or there is another fix the issue is easy to locate.

Example from logs:
`2025-09-23 14:12:38.612 WARNING dapla_metadata.datasets.model_validation: Type warning: <class 'dapla_metadata.datasets.model_validation.ObligatoryVariableWarning'>.
Obligatory metadata is missing:  [{'fnr': ['name', 'data_source', 'population_description']}, {'sivilstand': ['data_source', 'population_description']}, {'bostedskommune': ['data_source', 'population_description']}, {'inntekt': ['data_source', 'population_description']}, {'bankinnskudd': ['data_source', 'population_description']}, {'dato': ['data_source', 'population_description']}]

2025-09-23 14:12:38.613 WARNING dapla_metadata.datasets.model_validation: Type warning: <class 'dapla_metadata.datasets.model_validation.ObligatoryVariableWarning'>.Obligatory metadata is missing:  
[{'fnr': []}, {'sivilstand': []}, {'bostedskommune': []}, {'inntekt': []}, {'bankinnskudd': []}, {'dato': []}]
`
