### PR TITLE
Correct error message naming format

### DIFF
--- a/src/datadoc_editor/frontend/callbacks/dataset_callbacks.py
+++ b/src/datadoc_editor/frontend/callbacks/dataset_callbacks.py
@@ -57,7 +57,7 @@ def register_dataset_callbacks(app: Dash) -> None:
         ),
         Output(
             {"type": DATASET_METADATA_INPUT, "id": MATCH},
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {"type": DATASET_METADATA_INPUT, "id": MATCH},
@@ -92,7 +92,7 @@ def register_dataset_callbacks(app: Dash) -> None:
                 "id": MATCH,
                 "language": MATCH,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {
@@ -135,7 +135,7 @@ def register_dataset_callbacks(app: Dash) -> None:
                 "field": MATCH,
                 "index": MATCH,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {
@@ -208,7 +208,7 @@ def register_dataset_callbacks(app: Dash) -> None:
                 "type": DATASET_METADATA_DATE_INPUT,
                 "id": DatasetIdentifiers.CONTAINS_DATA_FROM.value,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Output(
             {
@@ -222,7 +222,7 @@ def register_dataset_callbacks(app: Dash) -> None:
                 "type": DATASET_METADATA_DATE_INPUT,
                 "id": DatasetIdentifiers.CONTAINS_DATA_UNTIL.value,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {

--- a/src/datadoc_editor/frontend/callbacks/pseudonymization_callbacks.py
+++ b/src/datadoc_editor/frontend/callbacks/pseudonymization_callbacks.py
@@ -81,7 +81,7 @@ def register_pseudonymization_callbacks(app: Dash) -> None:
         ),
         Output(
             {"type": PSEUDO_METADATA_INPUT, "variable_short_name": MATCH, "id": MATCH},
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {"type": PSEUDO_METADATA_INPUT, "variable_short_name": MATCH, "id": MATCH},

--- a/src/datadoc_editor/frontend/callbacks/variables_callbacks.py
+++ b/src/datadoc_editor/frontend/callbacks/variables_callbacks.py
@@ -87,7 +87,7 @@ def register_variables_callbacks(app: Dash) -> None:
                 "id": MATCH,
                 "language": MATCH,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {
@@ -131,7 +131,7 @@ def register_variables_callbacks(app: Dash) -> None:
                 "variable_short_name": MATCH,
                 "id": VariableIdentifiers.CONTAINS_DATA_FROM.value,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Output(
             {
@@ -147,7 +147,7 @@ def register_variables_callbacks(app: Dash) -> None:
                 "variable_short_name": MATCH,
                 "id": VariableIdentifiers.CONTAINS_DATA_UNTIL.value,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {
@@ -194,7 +194,7 @@ def register_variables_callbacks(app: Dash) -> None:
                 "variable_short_name": MATCH,
                 "id": MATCH,
             },
-            "errormessage",
+            "errorMessage",
         ),
         Input(
             {


### PR DESCRIPTION
`errorMessage` was changed to `errormessage` because of warning from React: 

"hook.js:608 Warning: React does not recognize the `errorMessage` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `errormessage` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack"

This change of format caused date fields to not display error messages. It has now been corrected.

<img width="821" height="162" alt="Skjermbilde 2025-10-07 kl  14 04 31" src="https://github.com/user-attachments/assets/e71bc3bd-028c-4404-b92c-e35933dbc848" />
