### PR TITLE
Use localhost when selecting a random free port

### DIFF
--- a/src/datadoc_editor/app.py
+++ b/src/datadoc_editor/app.py
@@ -26,7 +26,7 @@ from datadoc_editor.frontend.components.control_bars import build_footer_control
 from datadoc_editor.frontend.components.control_bars import header
 from datadoc_editor.logging_configuration.logging_config import get_log_config
 from datadoc_editor.utils import get_app_version
-from datadoc_editor.utils import pick_random_port
+from datadoc_editor.utils import pick_free_local_port
 from datadoc_editor.utils import running_in_notebook
 
 logging.config.dictConfig(get_log_config())
@@ -108,7 +108,7 @@ def get_app(
 
     # The service prefix must be set to run correctly on Dapla Jupyter
     if prefix := config.get_jupyterhub_service_prefix():
-        port = pick_random_port()
+        port = pick_free_local_port()
         requests_pathname_prefix = f"{prefix}proxy/{port}/"
     else:
         port = config.get_port()

--- a/src/datadoc_editor/utils.py
+++ b/src/datadoc_editor/utils.py
@@ -20,7 +20,7 @@ def running_in_notebook() -> bool:
         return False
 
 
-def pick_random_port() -> int:
+def pick_free_local_port() -> int:
     """Pick a random free port number.
 
     The function binds a socket to 127.0.0.1 on port 0, which lets the

--- a/src/datadoc_editor/utils.py
+++ b/src/datadoc_editor/utils.py
@@ -29,7 +29,7 @@ def pick_random_port() -> int:
     import socket  # noqa: PLC0415
 
     with socket.socket() as sock:
-        sock.bind(("", 0))
+        sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
 
 

--- a/src/datadoc_editor/utils.py
+++ b/src/datadoc_editor/utils.py
@@ -23,8 +23,8 @@ def running_in_notebook() -> bool:
 def pick_random_port() -> int:
     """Pick a random free port number.
 
-    The function will bind a socket to port 0, and a random free port from
-    1024 to 65535 will be selected by the operating system.
+    The function binds a socket to 127.0.0.1 on port 0, which lets the
+    operating system select an available temporary port.
     """
     import socket  # noqa: PLC0415
 


### PR DESCRIPTION
Update the random port selection helper to bind the temporary socket to 127.0.0.1 instead of all network interfaces.
Binding to all interfaces using an empty host ("") trigger a security warning.